### PR TITLE
Stop quitting the whole app when the only dialog window is closed

### DIFF
--- a/flock_agent/gui/__init__.py
+++ b/flock_agent/gui/__init__.py
@@ -10,6 +10,7 @@ from .main_window import MainWindow
 def main(common):
     # Create the Qt app
     app = QtWidgets.QApplication(sys.argv)
+    app.setQuitOnLastWindowClosed(False)
 
     # Attach the GuiCommon object to Common
     common.gui = GuiCommon(common)


### PR DESCRIPTION
Fixes #6.

It turns out the problem was the dialog window, not the subprocess. When you close the last window, Qt5 closes the whole application, even if the system tray applet is still open. So I disabled this. See also: https://stackoverflow.com/a/28394908