### PR TITLE
Improve homebrew

### DIFF
--- a/flock_agent/gui/gui_common.py
+++ b/flock_agent/gui/gui_common.py
@@ -26,6 +26,14 @@ class GuiCommon(object):
                 }
                 """,
 
+            'HomebrewView package_names': """
+                QLabel {
+                    font-weight: bold;
+                    padding-top: 10px;
+                    padding-bottom: 10px;
+                }
+                """,
+
             'TwigView name_label': """
                 QLabel {
                     font-weight: bold;

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtCore, QtWidgets, QtGui
 
-from .tabs import HealthTab, TwigsTab, SettingsTab
+from .tabs import HomebrewTab, HealthTab, TwigsTab, SettingsTab
 from .systray import SysTray
 
 
@@ -29,6 +29,8 @@ class MainWindow(QtWidgets.QMainWindow):
         header_layout.addStretch()
 
         # Tabs
+        self.homebrew_tab = HomebrewTab(self.c)
+
         self.health_tab = HealthTab(self.c)
 
         self.opt_in_tab = TwigsTab(self.c, is_opt_in=True)
@@ -55,6 +57,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # System tray
         self.systray = SysTray(self.c)
         self.systray.activated.connect(self.toggle_window)
+        self.systray.homebrew_updates_available.connect(self.homebrew_updates_available)
 
         self.update_ui()
 
@@ -76,7 +79,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.c.log("MainWindow", "update_ui")
 
         # Update the tabs
-        self.health_tab.update_ui()
         self.opt_in_tab.update_ui()
         self.data_tab.update_ui()
         self.settings_tab.update_ui()
@@ -88,6 +90,9 @@ class MainWindow(QtWidgets.QMainWindow):
         twigs_tab_index = self.tabs.indexOf(self.data_tab)
         if twigs_tab_index != -1:
             self.tabs.removeTab(twigs_tab_index)
+        homebrew_tab_index = self.tabs.indexOf(self.homebrew_tab)
+        if homebrew_tab_index != -1:
+            self.tabs.removeTab(homebrew_tab_index)
 
         # Add tabs that should be shown
         twigs_tab_should_show = len(self.c.settings.get_decided_twig_ids()) > 0
@@ -96,21 +101,33 @@ class MainWindow(QtWidgets.QMainWindow):
         opt_in_tab_should_show = len(self.c.settings.get_undecided_twig_ids()) > 0
         if opt_in_tab_should_show:
             self.tabs.insertTab(0, self.opt_in_tab, "Opt-In")
+        if self.homebrew_tab.should_show:
+            self.tabs.insertTab(0, self.homebrew_tab, "Homebrew")
 
-        if active_tab == 'opt-in':
-            index = self.tabs.indexOf(self.opt_in_tab)
-            if index != -1:
-                self.tabs.setCurrentIndex(index)
-            else:
-                active_tab = None
-        elif active_tab == 'data':
-            index = self.tabs.indexOf(self.data_tab)
-            if index != -1:
-                self.tabs.setCurrentIndex(index)
-            else:
-                active_tab = None
         if active_tab == None:
             self.tabs.setCurrentIndex(0)
+        else:
+            if active_tab == 'opt-in':
+                index = self.tabs.indexOf(self.opt_in_tab)
+            elif active_tab == 'data':
+                index = self.tabs.indexOf(self.data_tab)
+            elif active_tab == 'homebrew':
+                index = self.tabs.indexOf(self.homebrew_tab)
+            else:
+                index = -1
+
+            if index != -1:
+                self.tabs.setCurrentIndex(index)
+            else:
+                self.tabs.setCurrentIndex(0)
+
+    def homebrew_updates_available(self, outdated_formulae, outdated_casks):
+        self.homebrew_tab.homebrew_updates_available(outdated_formulae, outdated_casks)
+        self.update_ui('homebrew')
+        if not self.isVisible():
+            self.show()
+            self.activateWindow()
+            self.raise_()
 
     def toggle_window(self):
         self.c.log("MainWindow", "toggle_window")

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -34,7 +34,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Tabs
         self.homebrew_tab = HomebrewTab(self.c, self.systray)
-        self.homebrew_tab.homebrew_updates_available.connect(self.homebrew_updates_available)
+        self.homebrew_tab.update_homebrew_tab.connect(self.update_homebrew_tab)
 
         self.health_tab = HealthTab(self.c)
 
@@ -121,13 +121,15 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 self.tabs.setCurrentIndex(0)
 
-    def homebrew_updates_available(self):
-        self.update_ui('homebrew')
+    def update_homebrew_tab(self):
         if self.homebrew_tab.should_show:
+            self.update_ui('homebrew')
             if not self.isVisible():
                 self.show()
                 self.activateWindow()
                 self.raise_()
+        else:
+            self.update_ui()
 
     def toggle_window(self):
         self.c.log("MainWindow", "toggle_window")

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -16,6 +16,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle('Flock')
         self.setWindowIcon(self.c.gui.icon)
 
+        # System tray
+        self.systray = SysTray(self.c)
+        self.systray.activated.connect(self.toggle_window)
+
         # Header
         logo = QtWidgets.QLabel()
         logo.setPixmap(QtGui.QPixmap.fromImage(QtGui.QImage(self.c.get_resource_path("images/icon.png"))))
@@ -29,7 +33,8 @@ class MainWindow(QtWidgets.QMainWindow):
         header_layout.addStretch()
 
         # Tabs
-        self.homebrew_tab = HomebrewTab(self.c)
+        self.homebrew_tab = HomebrewTab(self.c, self.systray)
+        self.homebrew_tab.homebrew_updates_available.connect(self.homebrew_updates_available)
 
         self.health_tab = HealthTab(self.c)
 
@@ -53,11 +58,6 @@ class MainWindow(QtWidgets.QMainWindow):
         central_widget = QtWidgets.QWidget()
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
-
-        # System tray
-        self.systray = SysTray(self.c)
-        self.systray.activated.connect(self.toggle_window)
-        self.systray.homebrew_updates_available.connect(self.homebrew_updates_available)
 
         self.update_ui()
 
@@ -121,13 +121,13 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 self.tabs.setCurrentIndex(0)
 
-    def homebrew_updates_available(self, outdated_formulae, outdated_casks):
-        self.homebrew_tab.homebrew_updates_available(outdated_formulae, outdated_casks)
+    def homebrew_updates_available(self):
         self.update_ui('homebrew')
-        if not self.isVisible():
-            self.show()
-            self.activateWindow()
-            self.raise_()
+        if self.homebrew_tab.should_show:
+            if not self.isVisible():
+                self.show()
+                self.activateWindow()
+                self.raise_()
 
     def toggle_window(self):
         self.c.log("MainWindow", "toggle_window")

--- a/flock_agent/gui/systray.py
+++ b/flock_agent/gui/systray.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
-import subprocess
 from PyQt5 import QtCore, QtWidgets
 
 from .gui_common import Alert
 
 
 class SysTray(QtWidgets.QSystemTrayIcon):
-    homebrew_updates_available = QtCore.pyqtSignal(list, list)
-
     def __init__(self, common):
         super(SysTray, self).__init__(common.gui.systray_icon)
         self.c = common
@@ -20,11 +17,6 @@ class SysTray(QtWidgets.QSystemTrayIcon):
         self.submit_timer = QtCore.QTimer()
         self.submit_timer.timeout.connect(self.run_submit)
         self.submit_timer.start(60000) # 1 minute
-
-        # Check for homebrew updates once every 3 hours
-        self.homebrew_timer = QtCore.QTimer()
-        self.homebrew_timer.timeout.connect(self.run_homebrew)
-        self.homebrew_timer.start(30000) # start(10800000) # 3 hours
 
     def run_submit(self):
         if self.currently_submitting:
@@ -42,20 +34,6 @@ class SysTray(QtWidgets.QSystemTrayIcon):
     def submit_error(self, exception_type):
         # TODO: make the exception handling more robust
         self.showMessage("Error Submitting Data", "Exception type: {}".format(exception_type))
-
-    def run_homebrew(self):
-        self.homebrew_t = HomebrewThread(self.c)
-        self.homebrew_t.updates_available.connect(self.updates_available)
-        self.homebrew_t.installing_updates.connect(self.installing_updates)
-        self.homebrew_t.start()
-
-    def updates_available(self, outdated_formulae, outdated_casks):
-        self.c.log('SysTray', 'homebrew_updates_available', 'outdated_formulae: {}, outdated_casks: {}'.format(outdated_formulae, outdated_casks))
-        self.homebrew_updates_available.emit(outdated_formulae, outdated_casks)
-
-    def installing_updates(self, package_list):
-        self.c.log('SysTray', 'homebrew_installing_updates', package_list)
-        self.showMessage("Installing Homebrew Updates", '\n'.join(package_list))
 
 
 class SubmitThread(QtCore.QThread):
@@ -78,66 +56,3 @@ class SubmitThread(QtCore.QThread):
             self.c.log('SubmitThread', 'run', 'Exception submitting logs: {}'.format(exception_type))
             self.submit_error.emit(exception_type)
         self.submit_finished.emit()
-
-
-class HomebrewThread(QtCore.QThread):
-    """
-    Check for Homebrew updates
-    """
-    updates_available = QtCore.pyqtSignal(list, list)
-    installing_updates = QtCore.pyqtSignal(list)
-
-    def __init__(self, common):
-        super(HomebrewThread, self).__init__()
-        self.c = common
-
-    def run(self):
-        self.c.log('HomebrewThread', 'run')
-
-        homebrew_update_prompt = self.c.settings.get('homebrew_update_prompt')
-        homebrew_autoupdate = self.c.settings.get('homebrew_autoupdate')
-
-        if homebrew_update_prompt or homebrew_autoupdate:
-            # Update homebrew taps
-            self.exec(['/usr/local/bin/brew', 'update'])
-
-        outdated_formulae = []
-        outdated_casks = []
-
-        # If we want to prompt for updates, check for outdated formulae
-        # Also, we need to check for these if we will autoupdate
-        if homebrew_update_prompt or homebrew_autoupdate:
-            # See if there are any outdated formulae
-            p = self.exec(['/usr/local/bin/brew', 'outdated'])
-            if p:
-                stdout = p.stdout.decode().strip()
-                if stdout != '':
-                    outdated_formulae = [package.split(' ')[0] for package in stdout.split('\n')]
-
-            if len(outdated_formulae) > 0 and homebrew_autoupdate:
-                # Upgrade those formulae
-                self.installing_updates.emit(outdated_formulae)
-                self.exec(['/usr/local/bin/brew', 'upgrade'])
-                outdated_formulae = []
-
-        # If we want to prompt for updates, check for outdated casks
-        if homebrew_update_prompt:
-            # See if there are any outdated casks
-            p = self.exec(['/usr/local/bin/brew', 'cask', 'outdated'])
-            if p:
-                stdout = p.stdout.decode().strip()
-                if stdout != '':
-                    outdated_casks = [package.split(' ')[0] for package in stdout.split('\n')]
-
-            # Trigger the update prompt
-            # Note that if autodates are enabled, outdated_formulae should be a blank list
-            self.updates_available.emit(outdated_formulae, outdated_casks)
-
-    def exec(self, command):
-        try:
-            self.c.log('HomebrewThread', 'exec', 'Executing: {}'.format(' '.join(command)), always=True)
-            p = subprocess.run(command, capture_output=True, check=True)
-            return p
-        except subprocess.CalledProcessError:
-            self.c.log('HomebrewThread', 'exec', 'Error running command', always=True)
-            return False

--- a/flock_agent/gui/tabs/__init__.py
+++ b/flock_agent/gui/tabs/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .homebrew_tab import HomebrewTab
 from .health_tab import HealthTab
 from .twigs_tab import TwigsTab
 from .settings_tab import SettingsTab

--- a/flock_agent/gui/tabs/health_tab.py
+++ b/flock_agent/gui/tabs/health_tab.py
@@ -46,11 +46,6 @@ class HealthTab(QtWidgets.QWidget):
         layout.addLayout(buttons_layout)
         self.setLayout(layout)
 
-        self.update_ui()
-
-    def update_ui(self):
-        pass
-
     def clicked_refresh_button(self):
         self.c.log('HealthTab', 'clicked_refresh_button')
         for health_item in self.health_items:

--- a/flock_agent/gui/tabs/homebrew_tab.py
+++ b/flock_agent/gui/tabs/homebrew_tab.py
@@ -1,18 +1,21 @@
 # -*- coding: utf-8 -*-
+import subprocess
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 
 class HomebrewTab(QtWidgets.QWidget):
-    """
-    Homebrew
-    """
-    def __init__(self, common):
+    homebrew_updates_available = QtCore.pyqtSignal()
+
+    def __init__(self, common, systray):
         super(HomebrewTab, self).__init__()
         self.c = common
+        self.systray = systray
 
         self.c.log('HomebrewTab', '__init__')
 
         self.should_show = False
+        self.outdated_formulae = []
+        self.outdated_casks = []
 
         # Widgets
         self.formulae_label = QtWidgets.QLabel("Updates are available for the following packages:")
@@ -42,26 +45,123 @@ class HomebrewTab(QtWidgets.QWidget):
         layout.addStretch()
         self.setLayout(layout)
 
-    def homebrew_updates_available(self, outdated_formulae, outdated_casks):
-        self.c.log('HomebrewTab', 'homebrew_updates_available', 'outdated_formulae={}, outdated_casks={}'.format(outdated_formulae, outdated_casks))
-        self.should_show = True
+        # Check for homebrew updates once every 3 hours
+        self.update_check_timer = QtCore.QTimer()
+        self.update_check_timer.timeout.connect(self.update_check)
+        self.update_check_timer.start(10800000) # 3 hours
 
-        if len(outdated_formulae) == 0:
-            self.formulae_label.hide()
-            self.formulae_list_label.hide()
-        else:
-            self.formulae_label.show()
-            self.formulae_list_label.show()
-            self.formulae_list_label.setText('\n'.join(outdated_formulae))
+    def update_check(self):
+        self.homebrew_thread = HomebrewUpdateCheckThread(self.c)
+        self.homebrew_thread.updates_available.connect(self.updates_available)
+        self.homebrew_thread.installing_updates.connect(self.installing_updates)
+        self.homebrew_thread.start()
 
-        if len(outdated_casks) == 0:
-            self.casks_label.hide()
-            self.casks_list_label.hide()
+    def updates_available(self, outdated_formulae, outdated_casks):
+        self.c.log('HomebrewTab', 'updates_available', 'outdated_formulae: {}, outdated_casks: {}'.format(outdated_formulae, outdated_casks))
+
+        self.outdated_formulae = outdated_formulae
+        self.outdated_casks = outdated_casks
+
+        if len(outdated_formulae) > 0 or len(outdated_casks) > 0:
+            self.should_show = True
+
+            if len(outdated_formulae) == 0:
+                self.formulae_label.hide()
+                self.formulae_list_label.hide()
+            else:
+                self.formulae_label.show()
+                self.formulae_list_label.show()
+                self.formulae_list_label.setText('\n'.join(outdated_formulae))
+
+            if len(outdated_casks) == 0:
+                self.casks_label.hide()
+                self.casks_list_label.hide()
+            else:
+                self.casks_label.show()
+                self.casks_list_label.show()
+                self.casks_list_label.setText('\n'.join(outdated_casks))
         else:
-            self.casks_label.show()
-            self.casks_list_label.show()
-            self.casks_list_label.setText('\n'.join(outdated_casks))
+            self.should_show = False
+
+        self.homebrew_updates_available.emit()
+
+    def installing_updates(self, package_list):
+        self.c.log('HomebrewTab', 'homebrew_installing_updates', package_list)
+        self.systray.showMessage("Installing Homebrew Updates", '\n'.join(package_list))
 
     def clicked_install_updates_button(self):
         self.c.log('HomebrewTab', 'clicked_install_updates_button')
-        subprocess.run('osascript -e \'tell application "Terminal" to do script "brew cask upgrade && exit"\'', shell=True)
+        self.should_show = False
+
+        cmds = []
+        if len(self.outdated_formulae) > 0:
+            cmds.append("brew upgrade")
+        if len(self.outdated_casks) > 0:
+            cmds.append("brew cask upgrade")
+        cmds.append("exit")
+        final_command = " && ".join(cmds)
+
+        subprocess.run('osascript -e \'tell application "Terminal" to do script "{}"\''.format(final_command), shell=True)
+
+
+class HomebrewUpdateCheckThread(QtCore.QThread):
+    """
+    Check for Homebrew updates
+    """
+    updates_available = QtCore.pyqtSignal(list, list)
+    installing_updates = QtCore.pyqtSignal(list)
+
+    def __init__(self, common):
+        super(HomebrewUpdateCheckThread, self).__init__()
+        self.c = common
+
+    def run(self):
+        self.c.log('HomebrewThread', 'run')
+
+        homebrew_update_prompt = self.c.settings.get('homebrew_update_prompt')
+        homebrew_autoupdate = self.c.settings.get('homebrew_autoupdate')
+
+        if homebrew_update_prompt or homebrew_autoupdate:
+            # Update homebrew taps
+            self.exec(['/usr/local/bin/brew', 'update'])
+
+        outdated_formulae = []
+        outdated_casks = []
+
+        # If we want to prompt for updates, check for outdated formulae
+        # Also, we need to check for these if we will autoupdate
+        if homebrew_update_prompt or homebrew_autoupdate:
+            # See if there are any outdated formulae
+            p = self.exec(['/usr/local/bin/brew', 'outdated'])
+            if p:
+                stdout = p.stdout.decode().strip()
+                if stdout != '':
+                    outdated_formulae = [package.split(' ')[0] for package in stdout.split('\n')]
+
+            if len(outdated_formulae) > 0 and homebrew_autoupdate:
+                # Upgrade those formulae
+                self.installing_updates.emit(outdated_formulae)
+                self.exec(['/usr/local/bin/brew', 'upgrade'])
+                outdated_formulae = []
+
+        # If we want to prompt for updates, check for outdated casks
+        if homebrew_update_prompt:
+            # See if there are any outdated casks
+            p = self.exec(['/usr/local/bin/brew', 'cask', 'outdated'])
+            if p:
+                stdout = p.stdout.decode().strip()
+                if stdout != '':
+                    outdated_casks = [package.split(' ')[0] for package in stdout.split('\n')]
+
+            # Trigger the update prompt
+            # Note that if autodates are enabled, outdated_formulae should be a blank list
+            self.updates_available.emit(outdated_formulae, outdated_casks)
+
+    def exec(self, command):
+        try:
+            self.c.log('HomebrewThread', 'exec', 'Executing: {}'.format(' '.join(command)), always=True)
+            p = subprocess.run(command, capture_output=True, check=True)
+            return p
+        except subprocess.CalledProcessError:
+            self.c.log('HomebrewThread', 'exec', 'Error running command', always=True)
+            return False

--- a/flock_agent/gui/tabs/homebrew_tab.py
+++ b/flock_agent/gui/tabs/homebrew_tab.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from PyQt5 import QtCore, QtWidgets, QtGui
+
+
+class HomebrewTab(QtWidgets.QWidget):
+    """
+    Homebrew
+    """
+    def __init__(self, common):
+        super(HomebrewTab, self).__init__()
+        self.c = common
+
+        self.c.log('HomebrewTab', '__init__')
+
+        self.should_show = False
+
+        # Widgets
+        self.formulae_label = QtWidgets.QLabel("Updates are available for the following packages:")
+        self.formulae_list_label = QtWidgets.QLabel()
+        self.formulae_list_label.setStyleSheet(self.c.gui.css['HomebrewView package_names'])
+        self.casks_label = QtWidgets.QLabel("Updates are available for the following apps:")
+        self.casks_list_label = QtWidgets.QLabel()
+        self.casks_list_label.setStyleSheet(self.c.gui.css['HomebrewView package_names'])
+        instructions_label = QtWidgets.QLabel('Click "Install Updates" to open a Terminal and install updates using Homebrew.\nYou may have to type your macOS password if asked.')
+
+        # Buttons
+        install_updates_button = QtWidgets.QPushButton("Install Updates")
+        install_updates_button.clicked.connect(self.clicked_install_updates_button)
+
+        buttons_layout = QtWidgets.QHBoxLayout()
+        buttons_layout.addWidget(install_updates_button)
+        buttons_layout.addStretch()
+
+        # Layout
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.formulae_label)
+        layout.addWidget(self.formulae_list_label)
+        layout.addWidget(self.casks_label)
+        layout.addWidget(self.casks_list_label)
+        layout.addWidget(instructions_label)
+        layout.addLayout(buttons_layout)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def homebrew_updates_available(self, outdated_formulae, outdated_casks):
+        self.c.log('HomebrewTab', 'homebrew_updates_available', 'outdated_formulae={}, outdated_casks={}'.format(outdated_formulae, outdated_casks))
+        self.should_show = True
+
+        if len(outdated_formulae) == 0:
+            self.formulae_label.hide()
+            self.formulae_list_label.hide()
+        else:
+            self.formulae_label.show()
+            self.formulae_list_label.show()
+            self.formulae_list_label.setText('\n'.join(outdated_formulae))
+
+        if len(outdated_casks) == 0:
+            self.casks_label.hide()
+            self.casks_list_label.hide()
+        else:
+            self.casks_label.show()
+            self.casks_list_label.show()
+            self.casks_list_label.setText('\n'.join(outdated_casks))
+
+    def clicked_install_updates_button(self):
+        self.c.log('HomebrewTab', 'clicked_install_updates_button')
+        subprocess.run('osascript -e \'tell application "Terminal" to do script "brew cask upgrade && exit"\'', shell=True)

--- a/flock_agent/gui/tabs/settings_tab.py
+++ b/flock_agent/gui/tabs/settings_tab.py
@@ -59,17 +59,17 @@ class SettingsTab(QtWidgets.QWidget):
         server_settings_group.setLayout(server_settings_layout)
 
         # Autoupdate homebrew checkbox
-        self.autoupdate_homebrew_checkbox = QtWidgets.QCheckBox("Automatically install Homebrew updates (recommended)")
-        self.autoupdate_homebrew_checkbox.stateChanged.connect(self.autoupdate_homebrew_toggled)
+        self.homebrew_update_prompt_checkbox = QtWidgets.QCheckBox("Prompt when Homebrew updates are available")
+        self.homebrew_update_prompt_checkbox.stateChanged.connect(self.homebrew_update_prompt_toggled)
 
         # Autoupdate homebrew cask checkbox
-        self.autoupdate_homebrew_cask_checkbox = QtWidgets.QCheckBox("Automatically update macOS GUI apps through Homebrew cask (recommended)")
-        self.autoupdate_homebrew_cask_checkbox.stateChanged.connect(self.autoupdate_homebrew_cask_toggled)
+        self.homebrew_autoupdate_checkbox = QtWidgets.QCheckBox("Automatically install Homebrew updates in the background (if they don't require typing a password)")
+        self.homebrew_autoupdate_checkbox.stateChanged.connect(self.homebrew_autoupdate_toggled)
 
         # Homebrew group
         homebrew_settings_layout = QtWidgets.QVBoxLayout()
-        homebrew_settings_layout.addWidget(self.autoupdate_homebrew_checkbox)
-        homebrew_settings_layout.addWidget(self.autoupdate_homebrew_cask_checkbox)
+        homebrew_settings_layout.addWidget(self.homebrew_update_prompt_checkbox)
+        homebrew_settings_layout.addWidget(self.homebrew_autoupdate_checkbox)
         homebrew_settings_group = QtWidgets.QGroupBox("Homebrew upgrade settings")
         homebrew_settings_group.setLayout(homebrew_settings_layout)
 
@@ -116,17 +116,17 @@ class SettingsTab(QtWidgets.QWidget):
         else:
             self.automatically_enable_twigs_checkbox.setCheckState(QtCore.Qt.CheckState.Unchecked)
 
-        # Autoupdate homebrew checkbox
-        if self.c.settings.get('autoupdate_homebrew'):
-            self.autoupdate_homebrew_checkbox.setCheckState(QtCore.Qt.CheckState.Checked)
+        # Homebrew update prompt checkbox
+        if self.c.settings.get('homebrew_update_prompt'):
+            self.homebrew_update_prompt_checkbox.setCheckState(QtCore.Qt.CheckState.Checked)
         else:
-            self.autoupdate_homebrew_checkbox.setCheckState(QtCore.Qt.CheckState.Unchecked)
+            self.homebrew_update_prompt_checkbox.setCheckState(QtCore.Qt.CheckState.Unchecked)
 
-        # Autoupdate homebrew cask checkbox
-        if self.c.settings.get('autoupdate_homebrew_cask'):
-            self.autoupdate_homebrew_cask_checkbox.setCheckState(QtCore.Qt.CheckState.Checked)
+        # Homebrew autoupdate checkbox
+        if self.c.settings.get('homebrew_autoupdate'):
+            self.homebrew_autoupdate_checkbox.setCheckState(QtCore.Qt.CheckState.Checked)
         else:
-            self.autoupdate_homebrew_cask_checkbox.setCheckState(QtCore.Qt.CheckState.Unchecked)
+            self.homebrew_autoupdate_checkbox.setCheckState(QtCore.Qt.CheckState.Unchecked)
 
     def server_button_clicked(self):
         self.c.log('SettingsTab', 'server_button_clicked')
@@ -176,16 +176,16 @@ class SettingsTab(QtWidgets.QWidget):
         self.c.settings.set('automatically_enable_twigs', is_checked)
         self.c.settings.save()
 
-    def autoupdate_homebrew_toggled(self):
-        self.c.log('SettingsTab', 'autoupdate_homebrew_toggled')
-        is_checked = self.autoupdate_homebrew_checkbox.checkState() == QtCore.Qt.CheckState.Checked
-        self.c.settings.set('autoupdate_homebrew', is_checked)
+    def homebrew_update_prompt_toggled(self):
+        self.c.log('SettingsTab', 'homebrew_update_prompt_toggled')
+        is_checked = self.homebrew_update_prompt_checkbox.checkState() == QtCore.Qt.CheckState.Checked
+        self.c.settings.set('homebrew_update_prompt', is_checked)
         self.c.settings.save()
 
-    def autoupdate_homebrew_cask_toggled(self):
-        self.c.log('SettingsTab', 'autoupdate_homebrew_cask_toggled')
-        is_checked = self.autoupdate_homebrew_cask_checkbox.checkState() == QtCore.Qt.CheckState.Checked
-        self.c.settings.set('autoupdate_homebrew_cask', is_checked)
+    def homebrew_autoupdate_toggled(self):
+        self.c.log('SettingsTab', 'homebrew_autoupdate_toggled')
+        is_checked = self.homebrew_autoupdate_checkbox.checkState() == QtCore.Qt.CheckState.Checked
+        self.c.settings.set('homebrew_autoupdate', is_checked)
         self.c.settings.save()
 
     def quit_clicked(self):

--- a/flock_agent/gui/tabs/settings_tab.py
+++ b/flock_agent/gui/tabs/settings_tab.py
@@ -51,6 +51,13 @@ class SettingsTab(QtWidgets.QWidget):
         self.automatically_enable_twigs_checkbox = QtWidgets.QCheckBox("Automatically opt-in to new data collection without asking me")
         self.automatically_enable_twigs_checkbox.stateChanged.connect(self.automatically_enable_twigs_toggled)
 
+        # Flock server group
+        server_settings_layout = QtWidgets.QVBoxLayout()
+        server_settings_layout.addLayout(server_layout)
+        server_settings_layout.addWidget(self.automatically_enable_twigs_checkbox)
+        server_settings_group = QtWidgets.QGroupBox("Flock server settings")
+        server_settings_group.setLayout(server_settings_layout)
+
         # Autoupdate homebrew checkbox
         self.autoupdate_homebrew_checkbox = QtWidgets.QCheckBox("Automatically install Homebrew updates (recommended)")
         self.autoupdate_homebrew_checkbox.stateChanged.connect(self.autoupdate_homebrew_toggled)
@@ -58,6 +65,13 @@ class SettingsTab(QtWidgets.QWidget):
         # Autoupdate homebrew cask checkbox
         self.autoupdate_homebrew_cask_checkbox = QtWidgets.QCheckBox("Automatically update macOS GUI apps through Homebrew cask (recommended)")
         self.autoupdate_homebrew_cask_checkbox.stateChanged.connect(self.autoupdate_homebrew_cask_toggled)
+
+        # Homebrew group
+        homebrew_settings_layout = QtWidgets.QVBoxLayout()
+        homebrew_settings_layout.addWidget(self.autoupdate_homebrew_checkbox)
+        homebrew_settings_layout.addWidget(self.autoupdate_homebrew_cask_checkbox)
+        homebrew_settings_group = QtWidgets.QGroupBox("Homebrew upgrade settings")
+        homebrew_settings_group.setLayout(homebrew_settings_layout)
 
         # Buttons
         quit_button = QtWidgets.QPushButton('Quit Flock Agent')
@@ -72,10 +86,8 @@ class SettingsTab(QtWidgets.QWidget):
 
         # Layout
         layout = QtWidgets.QVBoxLayout()
-        layout.addLayout(server_layout)
-        layout.addWidget(self.automatically_enable_twigs_checkbox)
-        layout.addWidget(self.autoupdate_homebrew_checkbox)
-        layout.addWidget(self.autoupdate_homebrew_cask_checkbox)
+        layout.addWidget(server_settings_group)
+        layout.addWidget(homebrew_settings_group)
         layout.addStretch()
         layout.addLayout(buttons_layout)
         self.setLayout(layout)

--- a/flock_agent/settings.py
+++ b/flock_agent/settings.py
@@ -19,8 +19,8 @@ class Settings(object):
             'gateway_username': None,
             'automatically_enable_twigs': False,
             'last_osquery_result_timestamp': 0, # Timestamp of the last osquery result sent to the server
-            'autoupdate_homebrew': True,
-            'autoupdate_homebrew_cask': True,
+            'homebrew_update_prompt': True,
+            'homebrew_autoupdate': True,
             'twigs': {}
         }
 

--- a/flock_agent/settings.py
+++ b/flock_agent/settings.py
@@ -20,7 +20,7 @@ class Settings(object):
             'automatically_enable_twigs': False,
             'last_osquery_result_timestamp': 0, # Timestamp of the last osquery result sent to the server
             'homebrew_update_prompt': True,
-            'homebrew_autoupdate': True,
+            'homebrew_autoupdate': False,
             'twigs': {}
         }
 


### PR DESCRIPTION
Resolves #21.

The homebrew settings have new names and work different. Now there's a setting for prompting for updates (both formulae and casks), which defaults to on, and another setting for auto-installing formulae updates, which defaults to off.

Instead of there being a popup dialog when updates are available, this shows the main window with a new Homebrew tab showing. (This way if updates are available and the user is away from their computer, it simply brings that tab forward and updates its text instead of popping up several windows.)

The `HomebrewTab` class is now responsible for all Homebrew-related code, including the timer to check for updates. The `SysTray` class doesn't bother with that anymore.