### PR TITLE
Optional server

### DIFF
--- a/flock_agent/gui/gui_common.py
+++ b/flock_agent/gui/gui_common.py
@@ -92,6 +92,12 @@ class GuiCommon(object):
                 }
                 """,
 
+            'SettingsTab group_box': """
+                QGroupBox {
+                    font-size: 14px;
+                }
+            """,
+
             'SettingsTab server_url_label': """
                 QLabel {
                     font-family: monospace;
@@ -171,3 +177,13 @@ class Alert(QtWidgets.QDialog):
 
     def launch(self):
         return self.exec_() == QtWidgets.QDialog.Accepted
+
+
+class HidableSpacer(QtWidgets.QWidget):
+    """
+    A custom widget that's used as spacing in a layout which can be shown or hidden
+    """
+    def __init__(self, size=10):
+        super(HidableSpacer, self).__init__()
+        self.setMinimumSize(size, size)
+        self.setMaximumSize(size, size)

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -179,7 +179,11 @@ class MainWindow(QtWidgets.QMainWindow):
             # Stop the submit timer
             self.submit_timer.stop()
 
+        # Either show or hide the opt-in and data tabs
         self.update_ui(active_tab)
+
+        # Either enable or disable osqueryd
+        self.c.osquery.refresh_osqueryd()
 
     def quit(self):
         self.c.log("MainWindow", "quit")

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -45,6 +45,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.data_tab.refresh.connect(self.update_ui)
 
         self.settings_tab = SettingsTab(self.c)
+        self.settings_tab.update_use_server.connect(self.update_use_server)
         self.settings_tab.quit.connect(self.quit)
 
         self.tabs = QtWidgets.QTabWidget()
@@ -59,19 +60,17 @@ class MainWindow(QtWidgets.QMainWindow):
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
 
-        self.update_ui()
-
         # Show or hide?
         if len(self.c.settings.get_undecided_twig_ids()) == 0:
             self.hide()
         else:
             self.show()
 
-        # Submit osquery logs to the server each minute
+        # Submit osquery logs to the server on a timer
         self.currently_submitting = False
         self.submit_timer = QtCore.QTimer()
         self.submit_timer.timeout.connect(self.run_submit)
-        self.submit_timer.start(60000) # 1 minute
+        self.update_use_server(None) # this calls self.update_ui()
 
     def closeEvent(self, e):
         """
@@ -93,23 +92,27 @@ class MainWindow(QtWidgets.QMainWindow):
         opt_in_tab_index = self.tabs.indexOf(self.opt_in_tab)
         if opt_in_tab_index != -1:
             self.tabs.removeTab(opt_in_tab_index)
-        twigs_tab_index = self.tabs.indexOf(self.data_tab)
-        if twigs_tab_index != -1:
-            self.tabs.removeTab(twigs_tab_index)
+        data_tab_index = self.tabs.indexOf(self.data_tab)
+        if data_tab_index != -1:
+            self.tabs.removeTab(data_tab_index)
         homebrew_tab_index = self.tabs.indexOf(self.homebrew_tab)
         if homebrew_tab_index != -1:
             self.tabs.removeTab(homebrew_tab_index)
 
-        # Add tabs that should be shown
-        twigs_tab_should_show = len(self.c.settings.get_decided_twig_ids()) > 0
-        if twigs_tab_should_show:
-            self.tabs.insertTab(1, self.data_tab, "Data")
-        opt_in_tab_should_show = len(self.c.settings.get_undecided_twig_ids()) > 0
-        if opt_in_tab_should_show:
-            self.tabs.insertTab(0, self.opt_in_tab, "Opt-In")
+        # Only show data or opt-in tabs if using a server
+        if self.c.settings.get('use_server'):
+            data_tab_should_show = len(self.c.settings.get_decided_twig_ids()) > 0
+            if data_tab_should_show:
+                self.tabs.insertTab(1, self.data_tab, "Data")
+            opt_in_tab_should_show = len(self.c.settings.get_undecided_twig_ids()) > 0
+            if opt_in_tab_should_show:
+                self.tabs.insertTab(0, self.opt_in_tab, "Opt-In")
+
+        # Only show homebrew tab if there are homebrew updates available
         if self.homebrew_tab.should_show:
             self.tabs.insertTab(0, self.homebrew_tab, "Homebrew")
 
+        # Set the active tab
         if active_tab == None:
             self.tabs.setCurrentIndex(0)
         else:
@@ -119,6 +122,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 index = self.tabs.indexOf(self.data_tab)
             elif active_tab == 'homebrew':
                 index = self.tabs.indexOf(self.homebrew_tab)
+            elif active_tab == 'settings':
+                index = self.tabs.indexOf(self.settings_tab)
             else:
                 index = -1
 
@@ -151,10 +156,10 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         self.currently_submitting = True
 
-        self.submit_t = SubmitThread(self.c)
-        self.submit_t.submit_finished.connect(self.submit_finished)
-        self.submit_t.submit_error.connect(self.submit_error)
-        self.submit_t.start()
+        self.submit_thread = SubmitThread(self.c)
+        self.submit_thread.submit_finished.connect(self.submit_finished)
+        self.submit_thread.submit_error.connect(self.submit_error)
+        self.submit_thread.start()
 
     def submit_finished(self):
         self.currently_submitting = False
@@ -162,6 +167,19 @@ class MainWindow(QtWidgets.QMainWindow):
     def submit_error(self, exception_type):
         # TODO: make the exception handling more robust
         self.systray.showMessage("Error Submitting Data", "Exception type: {}".format(exception_type))
+
+    def update_use_server(self, active_tab='settings'):
+        use_server = self.c.settings.get('use_server')
+
+        if use_server:
+            # Start the submit timer
+            self.submit_timer.start(60000) # 1 minute
+
+        else:
+            # Stop the submit timer
+            self.submit_timer.stop()
+
+        self.update_ui(active_tab)
 
     def quit(self):
         self.c.log("MainWindow", "quit")

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -67,6 +67,12 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             self.show()
 
+        # Submit osquery logs to the server each minute
+        self.currently_submitting = False
+        self.submit_timer = QtCore.QTimer()
+        self.submit_timer.timeout.connect(self.run_submit)
+        self.submit_timer.start(60000) # 1 minute
+
     def closeEvent(self, e):
         """
         Intercept close event, and instead minimize to systray
@@ -140,9 +146,54 @@ class MainWindow(QtWidgets.QMainWindow):
             self.activateWindow()
             self.raise_()
 
+    def run_submit(self):
+        if self.currently_submitting:
+            return
+        self.currently_submitting = True
+
+        self.submit_t = SubmitThread(self.c)
+        self.submit_t.submit_finished.connect(self.submit_finished)
+        self.submit_t.submit_error.connect(self.submit_error)
+        self.submit_t.start()
+
+    def submit_finished(self):
+        self.currently_submitting = False
+
+    def submit_error(self, exception_type):
+        # TODO: make the exception handling more robust
+        self.systray.showMessage("Error Submitting Data", "Exception type: {}".format(exception_type))
+
     def quit(self):
         self.c.log("MainWindow", "quit")
         self.app.quit()
 
     def shutdown(self):
         self.c.log("MainWindow", "shutdown")
+
+
+class SubmitThread(QtCore.QThread):
+    """
+    Submit osquery records to the Flock server
+    """
+    submit_finished = QtCore.pyqtSignal()
+    submit_error = QtCore.pyqtSignal(str)
+
+    def __init__(self, common):
+        super(SubmitThread, self).__init__()
+        self.c = common
+
+    def run(self):
+        if self.c.settings.get('use_server'):
+            self.c.log('SubmitThread', 'run')
+
+            try:
+                self.c.osquery.submit_logs()
+            except Exception as e:
+                exception_type = type(e).__name__
+                self.c.log('SubmitThread', 'run', 'Exception submitting logs: {}'.format(exception_type))
+                self.submit_error.emit(exception_type)
+
+        else:
+            self.c.log('SubmitThread', 'run', 'use_server=False, so skipping')
+
+        self.submit_finished.emit()

--- a/flock_agent/gui/systray.py
+++ b/flock_agent/gui/systray.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtCore, QtWidgets
 
-from .gui_common import Alert
-
 
 class SysTray(QtWidgets.QSystemTrayIcon):
     def __init__(self, common):
@@ -11,48 +9,3 @@ class SysTray(QtWidgets.QSystemTrayIcon):
 
         # Show the systray icon
         self.show()
-
-        # Submit osquery logs to the server each minute
-        self.currently_submitting = False
-        self.submit_timer = QtCore.QTimer()
-        self.submit_timer.timeout.connect(self.run_submit)
-        self.submit_timer.start(60000) # 1 minute
-
-    def run_submit(self):
-        if self.currently_submitting:
-            return
-        self.currently_submitting = True
-
-        self.submit_t = SubmitThread(self.c)
-        self.submit_t.submit_finished.connect(self.submit_finished)
-        self.submit_t.submit_error.connect(self.submit_error)
-        self.submit_t.start()
-
-    def submit_finished(self):
-        self.currently_submitting = False
-
-    def submit_error(self, exception_type):
-        # TODO: make the exception handling more robust
-        self.showMessage("Error Submitting Data", "Exception type: {}".format(exception_type))
-
-
-class SubmitThread(QtCore.QThread):
-    """
-    Submit osquery records to the Flock server
-    """
-    submit_finished = QtCore.pyqtSignal()
-    submit_error = QtCore.pyqtSignal(str)
-
-    def __init__(self, common):
-        super(SubmitThread, self).__init__()
-        self.c = common
-
-    def run(self):
-        self.c.log('SubmitThread', 'run')
-        try:
-            self.c.osquery.submit_logs()
-        except Exception as e:
-            exception_type = type(e).__name__
-            self.c.log('SubmitThread', 'run', 'Exception submitting logs: {}'.format(exception_type))
-            self.submit_error.emit(exception_type)
-        self.submit_finished.emit()

--- a/flock_agent/gui/tabs/settings_tab.py
+++ b/flock_agent/gui/tabs/settings_tab.py
@@ -12,6 +12,8 @@ class SettingsTab(QtWidgets.QWidget):
     Settings
     """
     quit = QtCore.pyqtSignal()
+    disable_use_server = QtCore.pyqtSignal()
+    enable_use_server = QtCore.pyqtSignal()
 
     STATUS_NOT_REGISTERED = 0
     STATUS_REGISTERED = 1
@@ -203,6 +205,11 @@ class SettingsTab(QtWidgets.QWidget):
         is_checked = self.use_server_checkbox.checkState() == QtCore.Qt.CheckState.Checked
         self.c.settings.set('use_server', is_checked)
         self.c.settings.save()
+
+        if is_checked:
+            self.enable_use_server.emit()
+        else:
+            self.disable_use_server.emit()
 
         self.update_ui()
 

--- a/flock_agent/gui/tabs/settings_tab.py
+++ b/flock_agent/gui/tabs/settings_tab.py
@@ -12,8 +12,7 @@ class SettingsTab(QtWidgets.QWidget):
     Settings
     """
     quit = QtCore.pyqtSignal()
-    disable_use_server = QtCore.pyqtSignal()
-    enable_use_server = QtCore.pyqtSignal()
+    update_use_server = QtCore.pyqtSignal()
 
     STATUS_NOT_REGISTERED = 0
     STATUS_REGISTERED = 1
@@ -205,12 +204,7 @@ class SettingsTab(QtWidgets.QWidget):
         is_checked = self.use_server_checkbox.checkState() == QtCore.Qt.CheckState.Checked
         self.c.settings.set('use_server', is_checked)
         self.c.settings.save()
-
-        if is_checked:
-            self.enable_use_server.emit()
-        else:
-            self.disable_use_server.emit()
-
+        self.update_use_server.emit()
         self.update_ui()
 
     def automatically_enable_twigs_toggled(self):

--- a/flock_agent/settings.py
+++ b/flock_agent/settings.py
@@ -14,13 +14,19 @@ class Settings(object):
         self.c.log("Settings", "__init__", "settings_filename: {}".format(self.settings_filename))
 
         self.default_settings = {
+            # Server settings
+            'use_server': True,
             'gateway_url': None,
             'gateway_token': None,
             'gateway_username': None,
             'automatically_enable_twigs': False,
             'last_osquery_result_timestamp': 0, # Timestamp of the last osquery result sent to the server
+
+            # Homebrew settings
             'homebrew_update_prompt': True,
             'homebrew_autoupdate': False,
+
+            # Twigs
             'twigs': {}
         }
 


### PR DESCRIPTION
Resolves #24.

This adds a "Share data with a remote Flock server" checkbox in the settings tab. Toggling it off will:

- Disable the submit timer, which submits osquery logs every minute
- Hide the opt-in and data tabs
- Stop the osqueryd service, and disable its launchd

Toggling it on will:

- Enable the submit timer
- Show the opt-in/data tabs
- Start the osqueryd service, and enable its launchd

<img width="656" alt="Screen Shot 2019-05-01 at 4 59 22 PM" src="https://user-images.githubusercontent.com/156128/57050625-7cd4db80-6c32-11e9-88eb-ed8e50a3a324.png">
