### PR TITLE
Flock Agent tells the server when twig settings change, or server is enabled/disabled

### DIFF
--- a/flock_agent/common.py
+++ b/flock_agent/common.py
@@ -33,6 +33,7 @@ class Common(object):
             with open(self.log_filename, "a") as f:
                 time_str = time.strftime("%Y-%m-%d %H:%M:%S")
                 f.write("{} {}\n".format(time_str, final_msg))
+            os.chmod(self.log_filename, 0o600)
 
     def get_resource_path(self, filename):
         # In dev mode, look for resources directory relative to python file

--- a/flock_agent/daemon/api_client.py
+++ b/flock_agent/daemon/api_client.py
@@ -85,11 +85,17 @@ class FlockApiClient(object):
 
     def submit(self, data):
         """
-        Submit data to the Flock server.
-        data should a string, not an object.
+        Submit data to the Flock server
         """
         self.c.log("FlockApiClient", "submit")
         self._make_request("/submit", "post", True, data)
+
+    def submit_flock_logs(self, data):
+        """
+        Submit flock logs to the Flock server
+        """
+        self.c.log("FlockApiClient", "submit_flock_logs")
+        self._make_request("/submit_flock_logs", "post", True, data)
 
     def _make_request(self, path, method, auth, data=None):
         url = self._build_url(path)

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -101,11 +101,19 @@ class Daemon:
                     self.c.log(
                         "Daemon",
                         "submit_loop",
-                        "Exception submitting logs: {}".format(exception_type),
+                        f"Exception submitting logs: {exception_type}",
                     )
 
                 # Submit Flock Agent logs
-                self.flock_log.submit_logs()
+                try:
+                    self.flock_log.submit_logs()
+                except Exception as e:
+                    exception_type = type(e).__name__
+                    self.c.log(
+                        "Daemon",
+                        "submit_loop",
+                        f"Exception submitting flock logs: {exception_type}",
+                    )
 
             # Wait a minute
             await asyncio.sleep(60)
@@ -125,7 +133,7 @@ class Daemon:
                 common_log(
                     "Daemon.http_server",
                     "AccessLogger",
-                    "{} {} {}".format(request.method, request.path, response.status),
+                    f"{request.method} {request.path} {response.status}",
                 )
 
         # Routes
@@ -153,14 +161,10 @@ class Daemon:
                 self.c.log(
                     "Daemon",
                     "http_server.set_settings",
-                    "skipping {}={}, because it's already set".format(key, val),
+                    f"skipping {key}={val}, because it's already set",
                 )
             else:
-                self.c.log(
-                    "Daemon",
-                    "http_server.set_settings",
-                    "setting {}={}".format(key, val),
-                )
+                self.c.log("Daemon", "http_server.set_settings", f"setting {key}={val}")
                 self.global_settings.set(key, val)
                 self.global_settings.save()
 
@@ -193,7 +197,7 @@ class Daemon:
                 self.c.log(
                     "Daemon",
                     "http_server.enable_undecided_twigs",
-                    "enabled twigs: {}".format(enabled_twig_ids),
+                    f"enabled twigs: {enabled_twig_ids}",
                 )
                 self.global_settings.save()
                 self.osquery.refresh_osqueryd()
@@ -250,14 +254,14 @@ class Daemon:
                 self.c.log(
                     "Daemon",
                     "http_server.update_twig_status",
-                    "enabled twigs: {}".format(enabled_twig_ids),
+                    f"enabled twigs: {enabled_twig_ids}",
                 )
                 self.flock_log.log(FlockLogTypes.TWIGS_ENABLED, enabled_twig_ids)
             if len(disabled_twig_ids) > 0:
                 self.c.log(
                     "Daemon",
                     "http_server.update_twig_status",
-                    "disabled twigs: {}".format(disabled_twig_ids),
+                    f"disabled twigs: {disabled_twig_ids}",
                 )
                 self.flock_log.log(FlockLogTypes.TWIGS_DISABLED, disabled_twig_ids)
 
@@ -310,11 +314,11 @@ class Daemon:
             except PermissionDenied:
                 return response_object(error="Permission denied")
             except BadStatusCode as e:
-                return response_object(error="Bad status code: {}".format(e))
+                return response_object(error=f"Bad status code: {e}")
             except ResponseIsNotJson:
                 return response_object(error="Server response is not JSON")
             except RespondedWithError as e:
-                return response_object(error="Server error: {}".format(e))
+                return response_object(error=f"Server error: {e}")
             except InvalidResponse:
                 return response_object(error="Server returned an invalid response")
             except ConnectionError:

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -279,10 +279,6 @@ class Daemon:
             else:
                 return response_object(error="invalid health_item_name")
 
-        async def refresh_osqueryd(request):
-            self.osquery.refresh_osqueryd()
-            return response_object()
-
         async def register_server(request):
             data = await request.json()
             try:
@@ -340,7 +336,6 @@ class Daemon:
         app.router.add_get("/twig_enabled_statuses", get_twig_enabled_statuses)
         app.router.add_post("/update_twig_status", update_twig_status)
         app.router.add_get("/exec_health/{health_item_name}", exec_health)
-        app.router.add_get("/refresh_osqueryd", refresh_osqueryd)
         app.router.add_post("/register_server", register_server)
 
         loop = asyncio.get_event_loop()

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -172,13 +172,6 @@ class Daemon:
 
             return response_object()
 
-        async def get_twig(request):
-            twig_id = request.match_info.get("twig_id", None)
-            try:
-                return response_object(self.global_settings.get_twig(twig_id))
-            except:
-                return response_object(error="invalid twig_id")
-
         async def exec_twig(request):
             twig_id = request.match_info.get("twig_id", None)
             try:
@@ -216,6 +209,9 @@ class Daemon:
 
         async def get_enabled_twig_ids(request):
             return response_object(self.global_settings.get_enabled_twig_ids())
+
+        async def get_twig_enabled_statuses(request):
+            return response_object(self.global_settings.get_twig_enabled_statuses())
 
         async def update_twig_status(request):
             twig_status = await request.json()
@@ -336,12 +332,12 @@ class Daemon:
         app.router.add_post("/shutdown", shutdown)
         app.router.add_get("/setting/{key}", get_setting)
         app.router.add_post("/setting/{key}", set_setting)
-        app.router.add_get("/twig/{twig_id}", get_twig)
         app.router.add_get("/exec_twig/{twig_id}", exec_twig)
         app.router.add_post("/enable_undecided_twigs", enable_undecided_twigs)
         app.router.add_get("/decided_twig_ids", get_decided_twig_ids)
         app.router.add_get("/undecided_twig_ids", get_undecided_twig_ids)
         app.router.add_get("/enabled_twig_ids", get_enabled_twig_ids)
+        app.router.add_get("/twig_enabled_statuses", get_twig_enabled_statuses)
         app.router.add_post("/update_twig_status", update_twig_status)
         app.router.add_get("/exec_health/{health_item_name}", exec_health)
         app.router.add_get("/refresh_osqueryd", refresh_osqueryd)

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -191,6 +191,7 @@ class Daemon:
                 return response_object(error="invalid twig_id")
 
         async def enable_undecided_twigs(request):
+            # If the user choose to automatically opt-in to new twigs, this enables them all
             enabled_twig_ids = []
             twig_ids = self.global_settings.get_undecided_twig_ids()
             for twig_id in twig_ids:
@@ -198,7 +199,7 @@ class Daemon:
                     self.global_settings.enable_twig(twig_id)
                     enabled_twig_ids.append(twig_id)
 
-            if len(enabled_twig_ids) > 0:
+            if enabled_twig_ids:
                 self.c.log(
                     "Daemon",
                     "http_server.enable_undecided_twigs",
@@ -251,18 +252,18 @@ class Daemon:
                     self.global_settings.disable_twig(twig_id)
                     disabled_twig_ids.append(twig_id)
 
-            if len(enabled_twig_ids) > 0 or len(disabled_twig_ids) > 0:
+            if enabled_twig_ids or disabled_twig_ids:
                 self.global_settings.save()
                 self.osquery.refresh_osqueryd()
 
-            if len(enabled_twig_ids) > 0:
+            if enabled_twig_ids:
                 self.c.log(
                     "Daemon",
                     "http_server.update_twig_status",
                     f"enabled twigs: {enabled_twig_ids}",
                 )
                 self.flock_log.log(FlockLogTypes.TWIGS_ENABLED, enabled_twig_ids)
-            if len(disabled_twig_ids) > 0:
+            if disabled_twig_ids:
                 self.c.log(
                     "Daemon",
                     "http_server.update_twig_status",

--- a/flock_agent/daemon/flock_logs.py
+++ b/flock_agent/daemon/flock_logs.py
@@ -1,0 +1,139 @@
+import os
+import time
+import json
+
+from .api_client import FlockApiClient
+
+
+class FlockLog:
+    def __init__(self, common, lib_dir):
+        self.c = common
+        self.filename = os.path.join(lib_dir, "flock.log")
+        self.c.log("FlockLog", "__init__", self.filename)
+
+        # If the log file doesn't exist, create an empty one
+        if not os.path.exists(self.filename):
+            open(self.filename, "a").close()
+            os.chmod(self.filename, 0o600)
+
+    def log(self, flock_log_type, twig_id):
+        with open(self.filename, "a") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": flock_log_type,
+                        "twig_id": twig_id,
+                        "unix_timestamp": int(time.time()),
+                    }
+                )
+                + "\n"
+            )
+        os.chmod(self.filename, 0o600)
+
+    def submit_logs(self):
+        # Keep track of the biggest timestamp we see
+        biggest_timestamp = self.c.global_settings.get("last_flock_log_timestamp")
+
+        # What's the results file's modified timestamp, before we start the import
+        try:
+            mtime = os.path.getmtime(self.filename)
+
+            # Load the log file
+            with open(self.filename, "r") as f:
+                lines = f.readlines()
+                if len(lines) > 0:
+                    self.c.log("FlockLog", "submit_logs", "{} lines".format(len(lines)))
+
+                    # Start an API client
+                    api_client = FlockApiClient(self.c)
+                    try:
+                        api_client.ping()
+                    except:
+                        self.c.log(
+                            "FlockLog",
+                            "submit_logs",
+                            "API is not configured properly",
+                            always=True,
+                        )
+                        return
+
+                    # Make a list of logs
+                    logs = []
+                    for line in lines:
+                        line = line.strip()
+                        try:
+                            obj = json.loads(line)
+                            if "timestamp" in obj:
+                                if "type" not in obj:
+                                    obj["type"] = "unknown"
+
+                                # If we haven't submitted this yet
+                                if obj["timestamp"] > self.c.global_settings.get(
+                                    "last_flock_log_timestamp"
+                                ):
+                                    logs.append(obj)
+                                else:
+                                    # Already submitted
+                                    self.c.log(
+                                        "FlockLog",
+                                        "submit_logs",
+                                        'skipping "{}" result, already submitted'.format(
+                                            obj["type"]
+                                        ),
+                                    )
+                            else:
+                                self.c.log(
+                                    "FlockLog",
+                                    "submit_logs",
+                                    "warning: timestamp not in line: {}".format(line),
+                                )
+
+                        except json.decoder.JSONDecodeError:
+                            self.c.log(
+                                "FlockLog",
+                                "submit_logs",
+                                "warning: line is not valid JSON: {}".format(line),
+                            )
+
+                    # Submit them
+                    api_client.submit_flock_logs(json.dumps(logs))
+                    self.c.log(
+                        "FlockLog",
+                        "submit_logs",
+                        "submitted logs: {}".format(
+                            ", ".join([obj["type"] for obj in logs])
+                        ),
+                    )
+
+                    # Update the biggest timestamp, if needed
+                    if logs[-1]["timestamp"] > biggest_timestamp:
+                        biggest_timestamp = logs[-1]["timestamp"]
+
+            # Update timestamp in settings
+            if (
+                self.c.global_settings.get("last_flock_log_timestamp")
+                < biggest_timestamp
+            ):
+                self.c.global_settings.set(
+                    "last_flock_log_timestamp", biggest_timestamp
+                )
+                self.c.global_settings.save()
+
+            # If the log file hasn't been modified since we started the import, truncate it
+            if mtime == os.path.getmtime(self.filename):
+                with open(self.filename, "w") as f:
+                    f.truncate()
+
+        except FileNotFoundError:
+            self.c.log(
+                "FlockLog",
+                "submit_logs",
+                "warning: file not found: {}".format(self.filename),
+            )
+
+
+class FlockLogTypes:
+    SERVER_ENABLED = "server_enabled"
+    SERVER_DISABLED = "server_disabled"
+    TWIG_ENABLED = "twig_enabled"
+    TWIG_DISABLED = "twig_disabled"

--- a/flock_agent/daemon/flock_logs.py
+++ b/flock_agent/daemon/flock_logs.py
@@ -16,13 +16,13 @@ class FlockLog:
             open(self.filename, "a").close()
             os.chmod(self.filename, 0o600)
 
-    def log(self, flock_log_type, twig_id=None):
+    def log(self, flock_log_type, twig_ids=None):
         with open(self.filename, "a") as f:
             f.write(
                 json.dumps(
                     {
                         "type": flock_log_type,
-                        "twig_id": twig_id,
+                        "twig_ids": twig_ids,
                         "timestamp": int(time.time()),
                     }
                 )
@@ -136,5 +136,5 @@ class FlockLog:
 class FlockLogTypes:
     SERVER_ENABLED = "server_enabled"
     SERVER_DISABLED = "server_disabled"
-    TWIG_ENABLED = "twig_enabled"
-    TWIG_DISABLED = "twig_disabled"
+    TWIGS_ENABLED = "twig_enabled"
+    TWIGS_DISABLED = "twig_disabled"

--- a/flock_agent/daemon/flock_logs.py
+++ b/flock_agent/daemon/flock_logs.py
@@ -16,14 +16,14 @@ class FlockLog:
             open(self.filename, "a").close()
             os.chmod(self.filename, 0o600)
 
-    def log(self, flock_log_type, twig_id):
+    def log(self, flock_log_type, twig_id=None):
         with open(self.filename, "a") as f:
             f.write(
                 json.dumps(
                     {
                         "type": flock_log_type,
                         "twig_id": twig_id,
-                        "unix_timestamp": int(time.time()),
+                        "timestamp": int(time.time()),
                     }
                 )
                 + "\n"
@@ -106,8 +106,9 @@ class FlockLog:
                     )
 
                     # Update the biggest timestamp, if needed
-                    if logs[-1]["timestamp"] > biggest_timestamp:
-                        biggest_timestamp = logs[-1]["timestamp"]
+                    if len(logs) > 0:
+                        if logs[-1]["timestamp"] > biggest_timestamp:
+                            biggest_timestamp = logs[-1]["timestamp"]
 
             # Update timestamp in settings
             if (

--- a/flock_agent/daemon/flock_logs.py
+++ b/flock_agent/daemon/flock_logs.py
@@ -136,5 +136,5 @@ class FlockLog:
 class FlockLogTypes:
     SERVER_ENABLED = "server_enabled"
     SERVER_DISABLED = "server_disabled"
-    TWIGS_ENABLED = "twig_enabled"
-    TWIGS_DISABLED = "twig_disabled"
+    TWIGS_ENABLED = "twigs_enabled"
+    TWIGS_DISABLED = "twigs_disabled"

--- a/flock_agent/daemon/global_settings.py
+++ b/flock_agent/daemon/global_settings.py
@@ -82,6 +82,12 @@ class GlobalSettings(object):
                 twig_ids.append(twig_id)
         return twig_ids
 
+    def get_twig_enabled_statuses(self):
+        enabled_statuses = {}
+        for twig_id in self.settings["twigs"]:
+            enabled_statuses[twig_id] = self.settings["twigs"][twig_id]["enabled"]
+        return enabled_statuses
+
     def load(self):
         self.c.log("GlobalSettings", "load")
         if os.path.isfile(self.settings_filename):

--- a/flock_agent/daemon/global_settings.py
+++ b/flock_agent/daemon/global_settings.py
@@ -31,6 +31,7 @@ class GlobalSettings(object):
             "gateway_username": None,
             "automatically_enable_twigs": False,
             "last_osquery_result_timestamp": 0,  # Timestamp of the last osquery result sent to the server
+            "last_flock_log_timestamp": 0,  # Timestamp of the last flock logs sent to the server
             # Twigs
             "twigs": {},
         }

--- a/flock_agent/daemon/global_settings.py
+++ b/flock_agent/daemon/global_settings.py
@@ -58,6 +58,9 @@ class GlobalSettings(object):
     def disable_twig(self, twig_id):
         self.settings["twigs"][twig_id]["enabled"] = "disabled"
 
+    def is_twig_enabled(self, twig_id):
+        return self.settings["twigs"][twig_id]["enabled"] == "enabled"
+
     def get_decided_twig_ids(self):
         twig_ids = []
         for twig_id in self.settings["twigs"]:

--- a/flock_agent/daemon/osquery.py
+++ b/flock_agent/daemon/osquery.py
@@ -63,9 +63,7 @@ class Osquery(object):
             self.c.log(
                 "Osquery",
                 "refresh_osqueryd",
-                "enabling twigs: {}".format(
-                    ", ".join(self.c.global_settings.get_enabled_twig_ids())
-                ),
+                f"enabling twigs: {', '.join(self.c.global_settings.get_enabled_twig_ids())}",
             )
 
             # Rebuild osquery config
@@ -174,7 +172,7 @@ class Osquery(object):
             with open(self.results_filename, "r") as results_file:
                 lines = results_file.readlines()
                 if len(lines) > 0:
-                    self.c.log("Osquery", "submit_logs", "{} lines".format(len(lines)))
+                    self.c.log("Osquery", "submit_logs", f"{len(lines)} lines")
 
                     # Start an API client
                     api_client = FlockApiClient(self.c)
@@ -184,7 +182,7 @@ class Osquery(object):
                         self.c.log(
                             "Osquery",
                             "submit_logs",
-                            "API is not configured properly",
+                            "Unable to communicate with the server",
                             always=True,
                         )
                         return
@@ -209,22 +207,20 @@ class Osquery(object):
                                     self.c.log(
                                         "Osquery",
                                         "submit_logs",
-                                        'skipping "{}" result, already submitted'.format(
-                                            obj["name"]
-                                        ),
+                                        f"skipping \"{obj['name']}\" result, already submitted",
                                     )
                             else:
                                 self.c.log(
                                     "Osquery",
                                     "submit_logs",
-                                    "warning: unixTime not in line: {}".format(line),
+                                    f"warning: unixTime not in line: {line}",
                                 )
 
                         except json.decoder.JSONDecodeError:
                             self.c.log(
                                 "Osquery",
                                 "submit_logs",
-                                "warning: line is not valid JSON: {}".format(line),
+                                f"warning: line is not valid JSON: {line}",
                             )
 
                     # Submit them
@@ -232,9 +228,7 @@ class Osquery(object):
                     self.c.log(
                         "Osquery",
                         "submit_logs",
-                        "submitted logs: {}".format(
-                            ", ".join([obj["name"] for obj in logs])
-                        ),
+                        f"submitted logs: {', '.join([obj['name'] for obj in logs])}",
                     )
 
                     # Update the biggest timestamp, if needed
@@ -262,5 +256,5 @@ class Osquery(object):
             self.c.log(
                 "Osquery",
                 "submit_logs",
-                "warning: file not found: {}".format(self.results_filename),
+                f"warning: file not found: {self.results_filename}",
             )

--- a/flock_agent/gui/daemon_client.py
+++ b/flock_agent/gui/daemon_client.py
@@ -63,12 +63,8 @@ class DaemonClient:
         res = self._http_get("/exec_twig/{}".format(twig_id))
         return res["data"]
 
-    def enable_twig(self, twig_id):
-        res = self._http_post("/enable_twig", twig_id)
-        return res["data"]
-
-    def disable_twig(self, twig_id):
-        res = self._http_post("/disable_twig", twig_id)
+    def enable_undecided_twigs(self):
+        res = self._http_post("/enable_undecided_twigs")
         return res["data"]
 
     def get_decided_twig_ids(self):
@@ -81,6 +77,10 @@ class DaemonClient:
 
     def get_enabled_twig_ids(self):
         res = self._http_get("/enabled_twig_ids")
+        return res["data"]
+
+    def update_twig_status(self, twig_status):
+        res = self._http_post("/update_twig_status", twig_status)
         return res["data"]
 
     def exec_health(self, health_item_name):

--- a/flock_agent/gui/daemon_client.py
+++ b/flock_agent/gui/daemon_client.py
@@ -55,10 +55,6 @@ class DaemonClient:
         res = self._http_post("/setting/{}".format(key), val)
         return res["data"]
 
-    def get_twig(self, twig_id):
-        res = self._http_get("/twig/{}".format(twig_id))
-        return res["data"]
-
     def exec_twig(self, twig_id):
         res = self._http_get("/exec_twig/{}".format(twig_id))
         return res["data"]
@@ -77,6 +73,10 @@ class DaemonClient:
 
     def get_enabled_twig_ids(self):
         res = self._http_get("/enabled_twig_ids")
+        return res["data"]
+
+    def get_twig_enabled_statuses(self):
+        res = self._http_get("/twig_enabled_statuses")
         return res["data"]
 
     def update_twig_status(self, twig_status):

--- a/flock_agent/gui/daemon_client.py
+++ b/flock_agent/gui/daemon_client.py
@@ -87,10 +87,6 @@ class DaemonClient:
         res = self._http_get("/exec_health/{}".format(health_item_name))
         return res["data"]
 
-    def refresh_osqueryd(self):
-        res = self._http_get("/refresh_osqueryd")
-        return res["data"]
-
     def register_server(self, server_url, name):
         res = self._http_post(
             "/register_server", {"server_url": server_url, "name": name}

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -56,7 +56,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.data_tab.refresh.connect(self.update_ui)
 
         self.settings_tab = SettingsTab(self.c)
-        self.settings_tab.update_use_server.connect(self.update_use_server)
+        self.settings_tab.update_use_server.connect(self.update_ui_settings)
         self.settings_tab.quit.connect(self.quit)
 
         self.tabs = QtWidgets.QTabWidget()
@@ -72,8 +72,7 @@ class MainWindow(QtWidgets.QMainWindow):
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
 
-        self.update_use_server(None)
-
+        self.update_ui()
         self.hide()
 
     def closeEvent(self, e):
@@ -150,6 +149,9 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 self.tabs.setCurrentIndex(0)
 
+    def update_ui_settings(self):
+        self.update_ui("settings")
+
     def update_homebrew_tab(self):
         if self.homebrew_tab.should_show:
             self.update_ui("homebrew")
@@ -168,20 +170,6 @@ class MainWindow(QtWidgets.QMainWindow):
             self.show()
             self.activateWindow()
             self.raise_()
-
-    def update_use_server(self, active_tab="settings"):
-        try:
-            # Either enable or disable osqueryd
-            self.c.daemon.refresh_osqueryd()
-        except DaemonNotRunningException:
-            self.c.gui.daemon_not_running()
-            return
-        except PermissionDeniedException:
-            self.c.gui.daemon_permission_denied()
-            return
-
-        # Either show or hide the opt-in and data tabs
-        self.update_ui(active_tab)
 
     def quit(self):
         self.c.log("MainWindow", "quit")

--- a/flock_agent/gui/tabs/twigs_tab.py
+++ b/flock_agent/gui/tabs/twigs_tab.py
@@ -100,6 +100,7 @@ class TwigsTab(QtWidgets.QWidget):
                 twig_ids = self.c.daemon.get_undecided_twig_ids()
             else:
                 twig_ids = self.c.daemon.get_decided_twig_ids()
+            twig_enabled_statuses = self.c.daemon.get_twig_enabled_statuses()
         except DaemonNotRunningException:
             self.c.gui.daemon_not_running()
             return
@@ -109,7 +110,7 @@ class TwigsTab(QtWidgets.QWidget):
 
         # Add them
         for twig_id in reversed(twig_ids):
-            twig_view = TwigView(self.c, twig_id)
+            twig_view = TwigView(self.c, twig_id, twig_enabled_statuses[twig_id])
             self.twig_views.append(twig_view)
             self.twigs_layout.insertWidget(0, twig_view)
 

--- a/flock_agent/gui/tabs/twigs_tab.py
+++ b/flock_agent/gui/tabs/twigs_tab.py
@@ -129,9 +129,7 @@ class TwigsTab(QtWidgets.QWidget):
                     )
                     self.c.daemon.set("automatically_enable_twigs", True)
 
-                for twig_id in self.c.daemon.get_undecided_twig_ids():
-                    self.c.daemon.enable_twig(twig_id)
-                self.c.daemon.refresh_osqueryd()
+                self.c.daemon.enable_undecided_twigs()
             except DaemonNotRunningException:
                 self.c.gui.daemon_not_running()
                 return
@@ -144,13 +142,15 @@ class TwigsTab(QtWidgets.QWidget):
     def clicked_apply_button(self):
         self.c.log("TwigsTab ({})".format(self.mode), "clicked_apply_button")
 
+        twig_status = {}
+        for twig_view in self.twig_views:
+            if twig_view.enabled_status == "enabled":
+                twig_status[twig_view.twig_id] = True
+            elif twig_view.enabled_status == "disabled":
+                twig_status[twig_view.twig_id] = False
+
         try:
-            for twig_view in self.twig_views:
-                if twig_view.enabled_status == "enabled":
-                    self.c.daemon.enable_twig(twig_view.twig_id)
-                elif twig_view.enabled_status == "disabled":
-                    self.c.daemon.disable_twig(twig_view.twig_id)
-            self.c.daemon.refresh_osqueryd()
+            self.c.daemon.update_twig_status(twig_status)
         except DaemonNotRunningException:
             self.c.gui.daemon_not_running()
             return

--- a/flock_agent/gui/twigs.py
+++ b/flock_agent/gui/twigs.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from PyQt5 import QtCore, QtWidgets, QtGui
 
-from .daemon_client import DaemonNotRunningException, PermissionDeniedException
 from ..twigs import twigs
 
 
@@ -10,13 +9,11 @@ class TwigView(QtWidgets.QWidget):
     The view of an individual twig
     """
 
-    def __init__(self, common, twig_id):
+    def __init__(self, common, twig_id, enabled_status):
         super(TwigView, self).__init__()
         self.c = common
         self.twig_id = twig_id
-
-        # Set the initial enabled status from settings
-        self.enabled_status = self.get_twig()["enabled"]
+        self.enabled_status = enabled_status
 
         # Widgets
         self.enabled_checkbox = QtWidgets.QCheckBox(twigs[twig_id]["name"])
@@ -75,14 +72,6 @@ class TwigView(QtWidgets.QWidget):
 
     def clicked_details_button(self):
         TwigDialog(self.c, self.twig_id)
-
-    def get_twig(self):
-        try:
-            return self.c.daemon.get_twig(self.twig_id)
-        except DaemonNotRunningException:
-            self.c.gui.daemon_not_running()
-        except PermissionDeniedException:
-            self.c.gui.daemon_permission_denied()
 
 
 class TwigDialog(QtWidgets.QDialog):

--- a/flock_agent/health.py
+++ b/flock_agent/health.py
@@ -104,7 +104,7 @@ def macos_sip_query_finished(data):
 health_items = {
     "macos": [
         {
-            "name": "FileVault",
+            "name": "filevault",
             "good_string": "FileVault is enabled",
             "bad_string": "FileVault should be enabled",
             "query": "select disk_encryption.encrypted from mounts join disk_encryption on mounts.device_alias = disk_encryption.name where mounts.path = '/'",
@@ -112,7 +112,7 @@ health_items = {
             "query_finished": macos_filevault_query_finished,
         },
         {
-            "name": "Gatekeeper",
+            "name": "gatekeeper",
             "good_string": "Gatekeeper is enabled",
             "bad_string": "Gatekeeper should be enabled",
             "query": "select assessments_enabled from gatekeeper",
@@ -120,7 +120,7 @@ health_items = {
             "query_finished": macos_gatekeeper_query_finished,
         },
         {
-            "name": "Firewall",
+            "name": "firewall",
             "good_string": "Firewall is enabled",
             "bad_string": "Firewall should be enabled",
             "query": "select global_state from alf",
@@ -128,7 +128,7 @@ health_items = {
             "query_finished": macos_firewall_query_finished,
         },
         {
-            "name": "Remote sharing",
+            "name": "remote_sharing",
             "good_string": "Remote sharing is disabled",
             "bad_string": "Remote sharing should be disabled",
             "query": "select * from sharing_preferences",
@@ -136,7 +136,7 @@ health_items = {
             "query_finished": macos_remote_sharing_query_finished,
         },
         {
-            "name": "macOS automatic updates",
+            "name": "macos_automatic_updates",
             "good_string": "macOS automatic updates are enabled",
             "bad_string": "macOS automatic updates should be enabled",
             "query": "select value from plist where path = '/Library/Preferences/com.apple.commerce.plist' and key = 'AutoUpdate'",
@@ -144,7 +144,7 @@ health_items = {
             "query_finished": macos_automatic_updates_query_finished,
         },
         {
-            "name": "Guest user",
+            "name": "guest_user",
             "good_string": "Guest user is disabled",
             "bad_string": "Guest user should be disabled",
             "query": "select value from plist where path='/Library/Preferences/com.apple.loginwindow.plist' and key='GuestEnabled'",
@@ -152,7 +152,7 @@ health_items = {
             "query_finished": macos_guest_user_query_finished,
         },
         {
-            "name": "System Integrity Protection",
+            "name": "sip",
             "good_string": "System Integrity Protection is enabled",
             "bad_string": "System Integrity Protection should be enabled",
             "query": "select enabled from sip_config where config_flag='sip'",


### PR DESCRIPTION
Resolves #38.

This introduces a new type of "flock logs", a log message that's just about Flock and not an osquery log. There are four types of flock logs so far: server_enabled, server_disabled, twigs_enabled, and twigs_disabled. They get logged to disk, and once a minute when the daemon tries submitting osquery logs to the server, it also tries submitting flock logs. (It works this way so that the server ends up getting flock logs even if they were generated when the daemon can't reach the server, like if wifi is disabled.)

This also does a bit of refactoring between the GUI and the daemon, removing unnecessary routes and making it so the GUI can send a single request to update the status of all twigs instead of having to send a separate request per twig.