### PR TITLE
Automatic updates for macOS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -54,9 +54,9 @@ pipenv run python -m pytest tests
 
 Install the needed dependencies:
 
-For Fedora-like distros: `dnf install -y rpm-build qt5-devel python3-qt5 python3-requests python3-appdirs python3-aiohttp python3-pytest python3-responses`
+For Fedora-like distros: `dnf install -y rpm-build qt5-devel python3-qt5 python3-requests python3-appdirs python3-aiohttp python3-packaging python3-pytest python3-responses`
 
-For Debian-like distros: `sudo apt install -y build-essential fakeroot python-all python3-all python3-stdeb dh-python python3-pyqt5 python3-requests python3-appdirs python3-aiohttp python3-pytest python3-responses`
+For Debian-like distros: `sudo apt install -y build-essential fakeroot python-all python3-all python3-stdeb dh-python python3-pyqt5 python3-requests python3-appdirs python3-aiohttp python3-packaging python3-pytest python3-responses`
 
 Here's how you run Flock Agent, without having to build a package:
 

--- a/Pipfile
+++ b/Pipfile
@@ -16,9 +16,10 @@ aiohttp = "==3.6.2"
 appdirs = "*"
 urllib3 = "*"
 pyqt5 = "*"
-pyobjc-core = { version = "*", platform_system = "== 'Darwin'" }
-pyobjc-framework-cocoa = { version = "*", platform_system = "== 'Darwin'" }
-pyobjc-framework-quartz = { version = "*", platform_system = "== 'Darwin'" }
+packaging = "*"
+pyobjc-core = {version = "*",platform_system = "== 'Darwin'"}
+pyobjc-framework-cocoa = {version = "*",platform_system = "== 'Darwin'"}
+pyobjc-framework-quartz = {version = "*",platform_system = "== 'Darwin'"}
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ce763acca6240532650da3b19014fb489d1f5b5fc2f3d995b47542bf5f28728"
+            "sha256": "293a77a3e0e195c91170cc75a9b10e367d1994bf53feff715af2d67d98a459f9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -99,6 +99,14 @@
             ],
             "version": "==4.7.4"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb",
+                "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"
+            ],
+            "index": "pypi",
+            "version": "==20.0"
+        },
         "pyobjc-core": {
             "hashes": [
                 "sha256:1a0fbf012fb575e0adf8c18cfd4453e657cc2c0deb2660c529bf524ba4c9149a",
@@ -131,6 +139,13 @@
             "index": "pypi",
             "markers": "platform_system == 'Darwin'",
             "version": "==6.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+            ],
+            "version": "==2.4.6"
         },
         "pyqt5": {
             "hashes": [
@@ -172,6 +187,13 @@
             ],
             "index": "pypi",
             "version": "==2.22.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+            ],
+            "version": "==1.13.0"
         },
         "urllib3": {
             "hashes": [
@@ -337,6 +359,7 @@
                 "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb",
                 "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"
             ],
+            "index": "pypi",
             "version": "==20.0"
         },
         "pathspec": {
@@ -448,29 +471,30 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161",
-                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
-                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
-                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
-                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
-                "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47",
-                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
-                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
-                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
-                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
-                "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2",
-                "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e",
-                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
-                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
-                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
-                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
-                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
-                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
-                "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66",
-                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
             "markers": "implementation_name == 'cpython' and python_version < '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.4.1"
         },
         "urllib3": {
             "hashes": [

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -367,6 +367,8 @@ class Daemon:
         if Platform.current() != Platform.MACOS:
             return
 
+        update_check_delay = 43200  # 12 hours
+
         while True:
             self.c.log("Daemon", "autoupdate_loop", "Checking for updates")
 
@@ -383,6 +385,7 @@ class Daemon:
                     f"installed version: {self.c.version}, latest version: {latest_version}",
                 )
                 if latest_version <= self.c.version:
+                    await asyncio.sleep(update_check_delay)
                     continue
 
                 # Find the pkg asset
@@ -396,6 +399,7 @@ class Daemon:
 
                 if not url:
                     self.c.log("Daemon", "autoupdate_loop", "could not find .pkg file")
+                    await asyncio.sleep(update_check_delay)
                     continue
 
                 # Download the update
@@ -430,6 +434,7 @@ class Daemon:
                         "autoupdate_loop",
                         f"codesign verification failed: {p.stdout.decode()}",
                     )
+                    await asyncio.sleep(update_check_delay)
                     continue
 
                 # Install the update
@@ -449,6 +454,3 @@ class Daemon:
                     "autoupdate_loop",
                     f"Exception while checking for updates: {e}",
                 )
-
-            # Wait 12 hours
-            await asyncio.sleep(43200)

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -422,7 +422,7 @@ class Daemon:
                     p.returncode != 0
                     or "Status: signed by a developer certificate issued by Apple for distribution"
                     not in p.stdout.decode()
-                    or "Developer ID Installer: FIRST LOOK PRODUCTIONS"
+                    or "Developer ID Installer: FIRST LOOK PRODUCTIONS, INC. ("
                     not in p.stdout.decode()
                 ):
                     self.c.log(

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -5,6 +5,8 @@ import grp
 import asyncio
 import json
 import time
+import requests
+import subprocess
 from urllib.parse import urlparse
 from aiohttp import web
 from aiohttp.abc import AbstractAccessLogger
@@ -51,17 +53,17 @@ class Daemon:
 
         # Flock Agent lib directory
         if Platform.current() == Platform.MACOS:
-            lib_dir = "/usr/local/var/lib/flock-agent"
+            self.lib_dir = "/usr/local/var/lib/flock-agent"
         else:
-            lib_dir = "/var/lib/flock-agent"
-        os.makedirs(lib_dir, exist_ok=True)
+            self.lib_dir = "/var/lib/flock-agent"
+        os.makedirs(self.lib_dir, exist_ok=True)
 
         # Flock Agent keeps its own submission queue separate from osqueryd, for when users
         # enable/disable the server, or enable/disable twigs
-        self.flock_log = FlockLog(self.c, lib_dir)
+        self.flock_log = FlockLog(self.c, self.lib_dir)
 
         # Prepare the unix socket path
-        self.unix_socket_path = os.path.join(lib_dir, "socket")
+        self.unix_socket_path = os.path.join(self.lib_dir, "socket")
         if os.path.exists(self.unix_socket_path):
             os.remove(self.unix_socket_path)
 
@@ -86,7 +88,9 @@ class Daemon:
         self.osquery.refresh_osqueryd()
 
     async def start(self):
-        await asyncio.gather(self.submit_loop(), self.http_server())
+        await asyncio.gather(
+            self.submit_loop(), self.http_server(), self.autoupdate_loop()
+        )
 
     async def submit_loop(self):
         while True:
@@ -357,3 +361,94 @@ class Daemon:
         # Change permissions of unix socket
         os.chmod(self.unix_socket_path, 0o660)
         os.chown(self.unix_socket_path, 0, self.gid)
+
+    async def autoupdate_loop(self):
+        # Autoupdate is only available for macOS right now; Linux uses package managers
+        if Platform.current() != Platform.MACOS:
+            return
+
+        while True:
+            self.c.log("Daemon", "autoupdate_loop", "Checking for updates")
+
+            try:
+                # Query github for the latest version of Flock Agent
+                r = requests.get(
+                    "https://api.github.com/repos/firstlookmedia/flock-agent/releases/latest"
+                )
+                release = r.json()
+                latest_version = release["tag_name"].lstrip("v")
+                self.c.log(
+                    "Daemon",
+                    "autoupdate_loop",
+                    f"installed version: {self.c.version}, latest version: {latest_version}",
+                )
+                if latest_version <= self.c.version:
+                    continue
+
+                # Find the pkg asset
+                url = None
+                filename = None
+                for asset in release["assets"]:
+                    if asset["name"].endswith(".pkg"):
+                        url = asset["browser_download_url"]
+                        filename = asset["name"]
+                        break
+
+                if not url:
+                    self.c.log("Daemon", "autoupdate_loop", "could not find .pkg file")
+                    continue
+
+                # Download the update
+                self.c.log("Daemon", "autoupdate_loop", f"downloading {url}")
+                r = requests.get(url)
+
+                os.makedirs(os.path.join(self.lib_dir, "updates"), exist_ok=True)
+                download_filename = os.path.join(self.lib_dir, "updates", filename)
+                with open(download_filename, "wb") as f:
+                    f.write(r.content)
+
+                self.c.log(
+                    "Daemon",
+                    "autoupdate_loop",
+                    f"download complete: {download_filename}",
+                )
+
+                # Verify that it's codesigned
+                p = subprocess.run(
+                    ["/usr/sbin/pkgutil", "--check-signature", download_filename],
+                    stdout=subprocess.PIPE,
+                )
+                if (
+                    p.returncode != 0
+                    or "Status: signed by a developer certificate issued by Apple for distribution"
+                    not in p.stdout.decode()
+                    or "Developer ID Installer: FIRST LOOK PRODUCTIONS"
+                    not in p.stdout.decode()
+                ):
+                    self.c.log(
+                        "Daemon",
+                        "autoupdate_loop",
+                        f"codesign verification failed: {p.stdout.decode()}",
+                    )
+                    continue
+
+                # Install the update
+                self.c.log(
+                    "Daemon",
+                    "autoupdate_loop",
+                    "launching installer background process and quitting daemon",
+                )
+                subprocess.Popen(
+                    ["/usr/sbin/installer", "-pkg", download_filename, "-target", "/"]
+                )
+                sys.exit(0)
+
+            except Exception as e:
+                self.c.log(
+                    "Daemon",
+                    "autoupdate_loop",
+                    f"Exception while checking for updates: {e}",
+                )
+
+            # Wait 12 hours
+            await asyncio.sleep(43200)

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -8,6 +8,7 @@ import time
 import requests
 import subprocess
 from urllib.parse import urlparse
+from packaging.version import parse as parse_version
 from aiohttp import web
 from aiohttp.abc import AbstractAccessLogger
 from aiohttp.web_runner import GracefulExit
@@ -384,7 +385,7 @@ class Daemon:
                     "autoupdate_loop",
                     f"installed version: {self.c.version}, latest version: {latest_version}",
                 )
-                if latest_version <= self.c.version:
+                if parse_version(latest_version) <= parse_version(self.c.version):
                     await asyncio.sleep(update_check_delay)
                     continue
 

--- a/install/linux/build_rpm.py
+++ b/install/linux/build_rpm.py
@@ -39,7 +39,7 @@ def main():
             "python3",
             "setup.py",
             "bdist_rpm",
-            "--requires=python3-qt5,python3-requests,python3-appdirs,python3-aiohttp",
+            "--requires=python3-qt5,python3-requests,python3-appdirs,python3-aiohttp,python3-packaging",
         ]
     )
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Package3: flock-agent
-Depends3: python3, python3-pyqt5, python3-requests, python3-appdirs, python3-aiohttp
+Depends3: python3, python3-pyqt5, python3-requests, python3-appdirs, python3-aiohttp, python3-packaging
 Build-Depends: python3, python3-all
 Suite: bionic
 X-Python3-Version: >= 3.7


### PR DESCRIPTION
This resolves #77.

Every 12 hours, the daemon tries to check for updates. It checks by looking at this repo's latest github release JSON object (https://api.github.com/repos/firstlookmedia/flock-agent/releases/latest). 

If there's a new version, it looks for the `.pkg` file and downloads it. Then it verifies that that `.pkg` file was codesigned with a developer certificate issued by Apple, and that has a codesigning identity that contains "Developer ID Installer: FIRST LOOK PRODUCTIONS". If the verification fails, it doesn't install the update.

If everything is good, it launches an installer subprocess to install the `.pkg` in the background and immediately quits. The installer itself has a post-install script that will restart the daemon and the GUI client when it's done upgrading.

If it hits an exception, like if the computer doesn't have internet, if github returns invalid JSON, etc, it skips this round and tries again 12 hours later.