### PR TITLE
Enable hardened runtime 

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -113,7 +113,7 @@ To make a macOS release, go to macOS build machine:
 - Run `pipenv run ./install/macos/build_pkg.py`; this will make a codesigned installer package called `dist/FlockAgent-$VERSION.pkg`
 - Notarize it: `xcrun altool --notarize-app --primary-bundle-id "media.firstlook.flock-agent" -u "micah@firstlook.org" -p "@keychain:flockagent-notarize" --file dist/FlockAgent-$VERSION.pkg`
 - Wait for it to get approved, check status with: `xcrun altool --notarization-history 0 -u "micah@firstlook.org" -p "@keychain:flockagent-notarize"`
-- (If it gets rejected, you can see why with: `xcrun altool --notarization-info [RequestUUID] -u "micah@firstlook.org" -p "@keychain:flockagent-notarize"`
+- (If it gets rejected, you can see why with: `xcrun altool --notarization-info [RequestUUID] -u "micah@firstlook.org" -p "@keychain:flockagent-notarize"`)
 - After it's approved, staple the ticket: `xcrun stapler staple dist/FlockAgent-$VERSION.pkg`
 
 This process ends up with the final file:

--- a/BUILD.md
+++ b/BUILD.md
@@ -104,20 +104,16 @@ git checkout v$VERSION
 
 To make a macOS release, go to macOS build machine:
 
-- Build machine should be running macOS 10.13
-- Verify and checkout the git tag for this release
-- Run `pipenv run ./install/macos/build_app.py`; this will make `dist/Flock.app` but won't codesign it
-- Copy `dist/Flock.app` from the build machine to the `dist` folder on the release machine
-
-Then move to the macOS release machine:
-
-- Release machine should be running the latest version of macOS, and must have:
+- Build machine must have:
+  - macOS 10.14
   - Apple-trusted `Developer ID Application: FIRST LOOK PRODUCTIONS, INC.` and `Developer ID Installer: FIRST LOOK PRODUCTIONS, INC.` code-signing certificates installed
   - An app-specific Apple ID password saved in the login keychain called `flockagent-notarize`
 - Verify and checkout the git tag for this release
+- Run `pipenv run ./install/macos/build_app.py`; this will make `dist/Flock.app` but won't codesign it
 - Run `pipenv run ./install/macos/build_pkg.py`; this will make a codesigned installer package called `dist/FlockAgent-$VERSION.pkg`
 - Notarize it: `xcrun altool --notarize-app --primary-bundle-id "media.firstlook.flock-agent" -u "micah@firstlook.org" -p "@keychain:flockagent-notarize" --file dist/FlockAgent-$VERSION.pkg`
 - Wait for it to get approved, check status with: `xcrun altool --notarization-history 0 -u "micah@firstlook.org" -p "@keychain:flockagent-notarize"`
+- (If it gets rejected, you can see why with: `xcrun altool --notarization-info [RequestUUID] -u "micah@firstlook.org" -p "@keychain:flockagent-notarize"`
 - After it's approved, staple the ticket: `xcrun stapler staple dist/FlockAgent-$VERSION.pkg`
 
 This process ends up with the final file:

--- a/install/macos/build_pkg.py
+++ b/install/macos/build_pkg.py
@@ -22,6 +22,9 @@ def run(cmd):
 
 
 def runtime_harden_osquery(build_path, osquery_filename, identity_name_application):
+    print(
+        "○ Extracting osquery package, re-signing it with hardened runtime, and flatting it"
+    )
     hardened_osquery_filename = os.path.splitext(osquery_filename)[0] + "-hardened.pkg"
 
     osquery_expanded_path = os.path.join(build_path, "osquery")
@@ -147,6 +150,9 @@ def main():
     version = flock_agent.flock_agent_version
 
     component_plist_path = os.path.join(root, "install/macos/packaging/component.plist")
+    entitlements_plist_path = os.path.join(
+        root, "install/macos/packaging/entitlements.plist"
+    )
     scripts_path = os.path.join(root, "install/macos/packaging/scripts")
     component_path = os.path.join(dist_path, "FlockAgentComponent.pkg")
     pkg_path = os.path.join(dist_path, "FlockAgent-{}.pkg".format(version))
@@ -201,7 +207,19 @@ def main():
 
         # Package with codesigning
         print("○ Codesigning app bundle")
-        run(["codesign", "--deep", "-s", identity_name_application, app_path])
+        run(
+            [
+                "codesign",
+                "--deep",
+                "-s",
+                identity_name_application,
+                "--entitlements",
+                entitlements_plist_path,
+                "-o",
+                "runtime",
+                app_path,
+            ]
+        )
 
         print("○ Creating an installer")
         run(

--- a/install/macos/packaging/entitlements.plist
+++ b/install/macos/packaging/entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Allow just-in-time compiled code, which is required by PyInstaller -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/install/macos/packaging/entitlements.plist
+++ b/install/macos/packaging/entitlements.plist
@@ -2,8 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Allow just-in-time compiled code, which is required by PyInstaller -->
+	<!-- These are required for binaries built by PyInstaller -->
 	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This enabled hardened runtime in both binaries shipped with the macOS package, osqueryd and flock-agent. Resolves #85.