### PR TITLE
During bootstrap, fail after 5 permission denieds

### DIFF
--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -367,6 +367,8 @@ class Daemon:
         os.chmod(self.unix_socket_path, 0o660)
         os.chown(self.unix_socket_path, 0, self.gid)
 
+        self.c.log("Daemon", "http_server", "Started http server")
+
     async def autoupdate_loop(self):
         # Autoupdate is only available for macOS right now; Linux uses package managers
         if Platform.current() != Platform.MACOS:

--- a/flock_agent/gui/bootstrap.py
+++ b/flock_agent/gui/bootstrap.py
@@ -78,21 +78,25 @@ class Bootstrap(object):
                     return False
 
         self.c.log("Bootstrap", "go", "Making sure the Flock Agent daemon is running")
-        try:
-            connected = False
-            for _ in range(10):
-                try:
-                    self.c.daemon.ping()
-                    connected = True
-                    break
-                except DaemonNotRunningException:
-                    self.c.log("Bootstrap", "go", "Failed to connect to daemon ...")
-                    time.sleep(1)
-            if not connected:
+        connected = False
+        permission_denied = False
+        for _ in range(5):
+            try:
+                self.c.daemon.ping()
+                connected = True
+                break
+            except DaemonNotRunningException:
+                self.c.log("Bootstrap", "go", "Failed to connect to daemon ...")
+                time.sleep(1)
+            except PermissionDeniedException:
+                self.c.log("Bootstrap", "go", "Permission denied ...")
+                permission_denied = True
+                time.sleep(1)
+        if not connected:
+            if permission_denied:
+                self.c.gui.daemon_permission_denied()
+            else:
                 self.c.gui.daemon_not_running()
-                return False
-        except PermissionDeniedException:
-            self.c.gui.daemon_permission_denied()
             return False
 
         self.c.log("Bootstrap", "go", "Bootstrap complete")


### PR DESCRIPTION
Resolves #97.

I confirmed that Flock Agent gives the Permission Denied error when it's supposed to, after being executed by a non-administrator user. But the error doesn't happen if the daemon is simply still booting up.