### PR TITLE
Use python's logging and split --verbosoe into --debug and --verbose

### DIFF
--- a/flock_agent/common.py
+++ b/flock_agent/common.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import os
-import sys
 import inspect
-import json
+import logging
+import os
 import platform
-import time
+import sys
+
 import appdirs
 
 
@@ -15,25 +15,12 @@ class Common(object):
 
     def __init__(self, verbose, version):
         self.verbose = verbose
-        self.log_filename = None
-        self.log("Common", "__init__")
+
+        logger = logging.getLogger("Common.__init__")
+        logger.debug("")
 
         self.version = version
         self.appdata_path = appdirs.user_config_dir("FlockAgent")
-
-    def log(self, module, func, msg="", always=False):
-        final_msg = "{}.{}".format(module, func)
-        if msg:
-            final_msg = "{}: {}".format(final_msg, msg)
-
-        if always or self.verbose:
-            print("○ {}".format(final_msg))
-
-        if self.log_filename:
-            with open(self.log_filename, "a") as f:
-                time_str = time.strftime("%Y-%m-%d %H:%M:%S")
-                f.write("{} {}\n".format(time_str, final_msg))
-            os.chmod(self.log_filename, 0o600)
 
     def get_resource_path(self, filename):
         # In dev mode, look for resources directory relative to python file

--- a/flock_agent/daemon/api_client.py
+++ b/flock_agent/daemon/api_client.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-import requests
 import base64
+import logging
+import requests
 
 
 class PermissionDenied(Exception):
@@ -58,10 +59,12 @@ class FlockApiClient(object):
 
     def __init__(self, common):
         self.c = common
-        self.c.log("FlockApiClient", "__init__")
+        logger = logging.getLogger("FlockApiClient.__init__")
+        logger.debug("")
 
     def register(self, name):
-        self.c.log("FlockApiClient", "register")
+        logger = logging.getLogger("FlockApiClient.register")
+        logger.debug("")
 
         obj = self._make_request(
             "/register",
@@ -79,21 +82,24 @@ class FlockApiClient(object):
         self.c.global_settings.save()
 
     def ping(self):
-        self.c.log("FlockApiClient", "ping")
+        logger = logging.getLogger("FlockApiClient.ping")
+        logger.debug("")
         self._make_request("/ping", "get", True)
 
     def submit(self, data):
         """
         Submit data to the Flock server
         """
-        self.c.log("FlockApiClient", "submit")
+        logger = logging.getLogger("FlockApiClient.submit")
+        logger.debug("")
         self._make_request("/submit", "post", True, data)
 
     def submit_flock_logs(self, data):
         """
         Submit flock logs to the Flock server
         """
-        self.c.log("FlockApiClient", "submit_flock_logs")
+        logger = logging.getLogger("FlockApiClient.submit_flock_logs")
+        logger.debug("")
         self._make_request("/submit_flock_logs", "post", True, data)
 
     def _make_request(self, path, method, auth, data=None):
@@ -107,18 +113,16 @@ class FlockApiClient(object):
         """
         url = self._build_url(path)
 
-        self.c.log("FlockApiClient", "_make_request", "{} {}".format(method, url))
+        logger = logging.getLogger("FlockApiClient._make_request")
+        logger.debug("{method} {url}")
 
         try:
             res = requests.request(
                 method, url, json=data, headers=self._get_headers(auth)
             )
 
-            self.c.log(
-                "FlockApiClient",
-                "_make_request",
-                "status_code: {}, data: {}".format(res.status_code, res.content),
-            )
+            logger.debug(f"status_code: {res.status_code}, data: {res.content}")
+
         except requests.exceptions.ConnectionError:
             raise ConnectionError()
 

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -130,7 +130,7 @@ class Daemon:
             self.flock_log.submit_logs()
         except Exception as e:
             exception_type = type(e).__name__
-            logger.info(f"Exception submitting flock logs: {exception_type}")
+            logger.warning(f"Exception submitting flock logs: {exception_type}")
 
     async def http_server(self):
         logger = logging.getLogger("Daemon.http_server")
@@ -382,7 +382,7 @@ class Daemon:
                         break
 
                 if not url:
-                    logger.info("could not find .pkg file")
+                    logger.warning("could not find .pkg file")
                     await asyncio.sleep(update_check_delay)
                     continue
 
@@ -415,7 +415,7 @@ class Daemon:
                     or "Developer ID Installer: FIRST LOOK PRODUCTIONS, INC. ("
                     not in p.stdout.decode()
                 ):
-                    logger.info(f"codesign verification failed: {p.stdout.decode()}")
+                    logger.warning(f"codesign verification failed: {p.stdout.decode()}")
                     await asyncio.sleep(update_check_delay)
                     continue
 
@@ -429,4 +429,4 @@ class Daemon:
                 sys.exit(0)
 
             except Exception as e:
-                logger.info(f"Exception while checking for updates: {e}")
+                logger.warning(f"Exception while checking for updates: {e}")

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -3,14 +3,12 @@ import os
 import sys
 import grp
 import asyncio
-import json
-import time
 import requests
 import subprocess
+import logging
 from urllib.parse import urlparse
 from packaging.version import parse as parse_version
 from aiohttp import web
-from aiohttp.abc import AbstractAccessLogger
 from aiohttp.web_runner import GracefulExit
 
 from .global_settings import GlobalSettings
@@ -31,6 +29,7 @@ from ..health import health_items
 
 class Daemon:
     def __init__(self, common):
+        logger = logging.getLogger(f"Daemon.__init__")
         self.c = common
 
         # Daemon's log
@@ -39,10 +38,17 @@ class Daemon:
         else:
             log_dir = "/var/log/flock-agent"
         os.makedirs(log_dir, exist_ok=True)
-        log_filename = os.path.join(log_dir, "log")
-        self.c.log_filename = log_filename
 
-        self.c.log("Daemon", "__init__", f"version {self.c.version}")
+        # Set up logging to a file.
+        base_logger = logging.getLogger("")
+        ch = logging.FileHandler(os.path.join(log_dir, "log"))
+        basic_formatter = logging.Formatter(
+            "%(asctime)s: %(levelname)s - %(name)s: %(message)s"
+        )
+        ch.setFormatter(basic_formatter)
+        base_logger.addHandler(ch)
+
+        logger.info(f"version {self.c.version}")
 
         self.osquery = Osquery(common)
         self.c.osquery = self.osquery
@@ -114,46 +120,33 @@ class Daemon:
             self.osquery.submit_logs()
         except Exception as e:
             exception_type = type(e).__name__
-            self.c.log(
-                "Daemon", "submit_loop", f"Exception submitting logs: {exception_type}"
-            )
+            logger = logging.getLogger("Daemon.submit_loop")
+            logger.debug(f"Exception submitting logs: {exception_type}")
 
     async def submit_logs_flock(self):
+        logger = logging.getLogger("Daemon.submit_logs_flock")
         # Submit Flock Agent logs
         try:
             self.flock_log.submit_logs()
         except Exception as e:
             exception_type = type(e).__name__
-            self.c.log(
-                "Daemon",
-                "submit_loop",
-                f"Exception submitting flock logs: {exception_type}",
-            )
+            logger.info(f"Exception submitting flock logs: {exception_type}")
 
     async def http_server(self):
-        self.c.log("Daemon", "http_server", "Starting http server")
+        logger = logging.getLogger("Daemon.http_server")
+        logger.info("Starting http server")
 
         def response_object(data=None, error=False):
             obj = {"data": data, "error": error}
             return web.json_response(obj)
-
-        # Access logs
-        common_log = self.c.log
-
-        class AccessLogger(AbstractAccessLogger):
-            def log(self, request, response, time):
-                common_log(
-                    "Daemon.http_server",
-                    "AccessLogger",
-                    f"{request.method} {request.path} {response.status}",
-                )
 
         # Routes
         async def ping(request):
             return response_object()
 
         async def shutdown(request):
-            self.c.log("Daemon", "http_server", "GET /shutdown, shutting down daemon")
+            logger = logging.getLogger("Daemon.http_server")
+            logger.info("GET /shutdown, shutting down daemon")
             raise GracefulExit()
 
         async def get_setting(request):
@@ -170,13 +163,10 @@ class Daemon:
             # Only change the setting if it's actually changing
             old_val = self.global_settings.get(key)
             if old_val == val:
-                self.c.log(
-                    "Daemon",
-                    "http_server.set_settings",
-                    f"skipping {key}={val}, because it's already set",
-                )
+                logger = logging.getLogger("Daemon.http_server.set_settings")
+                logger.debug(f"skipping {key}={val}, because it's already set",)
             else:
-                self.c.log("Daemon", "http_server.set_settings", f"setting {key}={val}")
+                logger.debug(f"setting {key}={val}")
                 self.global_settings.set(key, val)
                 self.global_settings.save()
 
@@ -200,6 +190,7 @@ class Daemon:
                 return response_object(error="invalid twig_id")
 
         async def enable_undecided_twigs(request):
+            logger = logging.getLogger("Daemon.http_server.enable_undecided_twigs")
             # If the user choose to automatically opt-in to new twigs, this enables them all
             enabled_twig_ids = []
             twig_ids = self.global_settings.get_undecided_twig_ids()
@@ -209,11 +200,7 @@ class Daemon:
                     enabled_twig_ids.append(twig_id)
 
             if enabled_twig_ids:
-                self.c.log(
-                    "Daemon",
-                    "http_server.enable_undecided_twigs",
-                    f"enabled twigs: {enabled_twig_ids}",
-                )
+                logger.debug(f"enabled twigs: {enabled_twig_ids}")
                 self.global_settings.save()
                 self.osquery.refresh_osqueryd()
                 self.flock_log.log(FlockLogTypes.TWIGS_ENABLED, enabled_twig_ids)
@@ -233,6 +220,7 @@ class Daemon:
             return response_object(self.global_settings.get_twig_enabled_statuses())
 
         async def update_twig_status(request):
+            logger = logging.getLogger("Daemon.update_twig_status")
             twig_status = await request.json()
 
             # Validate twig_status
@@ -267,18 +255,10 @@ class Daemon:
                 self.osquery.refresh_osqueryd()
 
             if enabled_twig_ids:
-                self.c.log(
-                    "Daemon",
-                    "http_server.update_twig_status",
-                    f"enabled twigs: {enabled_twig_ids}",
-                )
+                logger.info(f"enabled twigs: {enabled_twig_ids}")
                 self.flock_log.log(FlockLogTypes.TWIGS_ENABLED, enabled_twig_ids)
             if disabled_twig_ids:
-                self.c.log(
-                    "Daemon",
-                    "http_server.update_twig_status",
-                    f"disabled twigs: {disabled_twig_ids}",
-                )
+                logger.info(f"disabled twigs: {disabled_twig_ids}")
                 self.flock_log.log(FlockLogTypes.TWIGS_DISABLED, disabled_twig_ids)
 
             return response_object()
@@ -359,15 +339,13 @@ class Daemon:
         app.router.add_post("/register_server", register_server)
 
         loop = asyncio.get_event_loop()
-        await loop.create_unix_server(
-            app.make_handler(access_log_class=AccessLogger), self.unix_socket_path
-        )
+        await loop.create_unix_server(app.make_handler(), self.unix_socket_path)
 
         # Change permissions of unix socket
         os.chmod(self.unix_socket_path, 0o660)
         os.chown(self.unix_socket_path, 0, self.gid)
 
-        self.c.log("Daemon", "http_server", "Started http server")
+        logger.info("Started http server")
 
     async def autoupdate_loop(self):
         # Autoupdate is only available for macOS right now; Linux uses package managers
@@ -377,7 +355,8 @@ class Daemon:
         update_check_delay = 43200  # 12 hours
 
         while True:
-            self.c.log("Daemon", "autoupdate_loop", "Checking for updates")
+            logger = logging.getLogger("Daemon.autoupdate_loop")
+            logger.info("Checking for updates")
 
             try:
                 # Query github for the latest version of Flock Agent
@@ -386,9 +365,7 @@ class Daemon:
                 )
                 release = r.json()
                 latest_version = release["tag_name"].lstrip("v")
-                self.c.log(
-                    "Daemon",
-                    "autoupdate_loop",
+                logger.info(
                     f"installed version: {self.c.version}, latest version: {latest_version}",
                 )
                 if parse_version(latest_version) <= parse_version(self.c.version):
@@ -405,12 +382,12 @@ class Daemon:
                         break
 
                 if not url:
-                    self.c.log("Daemon", "autoupdate_loop", "could not find .pkg file")
+                    logger.info("could not find .pkg file")
                     await asyncio.sleep(update_check_delay)
                     continue
 
                 # Download the update
-                self.c.log("Daemon", "autoupdate_loop", f"downloading {url}")
+                logger.info(f"downloading {url}")
                 r = requests.get(url)
 
                 os.makedirs(os.path.join(self.lib_dir, "updates"), exist_ok=True)
@@ -418,11 +395,7 @@ class Daemon:
                 with open(download_filename, "wb") as f:
                     f.write(r.content)
 
-                self.c.log(
-                    "Daemon",
-                    "autoupdate_loop",
-                    f"download complete: {download_filename}",
-                )
+                logger.info(f"download complete: {download_filename}")
 
                 # Verify that it's codesigned
                 p = subprocess.run(
@@ -442,18 +415,12 @@ class Daemon:
                     or "Developer ID Installer: FIRST LOOK PRODUCTIONS, INC. ("
                     not in p.stdout.decode()
                 ):
-                    self.c.log(
-                        "Daemon",
-                        "autoupdate_loop",
-                        f"codesign verification failed: {p.stdout.decode()}",
-                    )
+                    logger.info(f"codesign verification failed: {p.stdout.decode()}")
                     await asyncio.sleep(update_check_delay)
                     continue
 
                 # Install the update
-                self.c.log(
-                    "Daemon",
-                    "autoupdate_loop",
+                logger.info(
                     "launching installer background process and quitting daemon",
                 )
                 subprocess.Popen(
@@ -462,8 +429,4 @@ class Daemon:
                 sys.exit(0)
 
             except Exception as e:
-                self.c.log(
-                    "Daemon",
-                    "autoupdate_loop",
-                    f"Exception while checking for updates: {e}",
-                )
+                logger.info(f"Exception while checking for updates: {e}")

--- a/flock_agent/daemon/flock_logs.py
+++ b/flock_agent/daemon/flock_logs.py
@@ -65,11 +65,11 @@ class FlockLog:
                     try:
                         obj = json.loads(line)
                     except json.decoder.JSONDecodeError:
-                        logger.info(f"warning: line is not valid JSON: {line}")
+                        logger.warning(f"warning: line is not valid JSON: {line}")
                         continue
 
                     if "timestamp" not in obj:
-                        logger.info(f"warning: timestamp not in line: {line}")
+                        logger.warning(f"warning: timestamp not in line: {line}")
                         continue
 
                     if "type" not in obj:
@@ -113,7 +113,7 @@ class FlockLog:
                     f.truncate()
 
         except FileNotFoundError:
-            logger.info(f"warning: file not found: {self.filename}")
+            logger.warning(f"warning: file not found: {self.filename}")
 
 
 class FlockLogTypes:

--- a/flock_agent/daemon/global_settings.py
+++ b/flock_agent/daemon/global_settings.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-import os
 import json
+import logging
+import os
+
 
 from ..twigs import twigs
 from ..common import Platform
@@ -20,11 +22,8 @@ class GlobalSettings(object):
             os.makedirs(etc_dir, exist_ok=True)
         self.settings_filename = os.path.join(etc_dir, "global_settings.json")
 
-        self.c.log(
-            "GlobalSettings",
-            "__init__",
-            "settings_filename: {}".format(self.settings_filename),
-        )
+        logger = logging.getLogger("GlobalSettings.__init__")
+        logger.info(f"settings_filename: {self.settings_filename}")
 
         self.default_settings = {
             # Server settings
@@ -49,7 +48,8 @@ class GlobalSettings(object):
         return self.settings[key]
 
     def set(self, key, val):
-        self.c.log("GlobalSettings", "set", "{} = {}".format(key, val))
+        logger = logging.getLogger("GlobalSettings.set")
+        logger.debug(f"{key} = {val}")
         self.settings[key] = val
 
     def get_twig(self, twig_id):
@@ -95,7 +95,8 @@ class GlobalSettings(object):
         return enabled_statuses
 
     def load(self, hostname):
-        self.c.log("GlobalSettings", "load")
+        logger = logging.getLogger("GlobalSettings.load")
+        logger.debug("")
         if os.path.isfile(self.settings_filename):
             self.first_run = False
 
@@ -111,22 +112,14 @@ class GlobalSettings(object):
 
             except:
                 # If there's an error loading settings, fallback to default settings
-                self.c.log(
-                    "GlobalSettings",
-                    "load",
-                    "error loading settings, falling back to default",
-                )
+                logger.info("error loading settings, falling back to default")
                 self.settings = self.default_settings.copy()
 
         else:
             self.first_run = True
 
             # Use default settings
-            self.c.log(
-                "GlobalSettings",
-                "load",
-                "settings file doesn't exist, starting with default",
-            )
+            logger.info("settings file doesn't exist, starting with default")
             self.settings = self.default_settings.copy()
 
         # Make sure gateway username is set
@@ -174,7 +167,8 @@ class GlobalSettings(object):
         self.save()
 
     def save(self):
-        self.c.log("GlobalSettings", "save")
+        logger = logging.getLogger("GlobalSettings.save")
+        logger.debug("saving")
         # When unit testing we likely won't have access to these directories and there's no point
         # saving config data.
         if not self.testing:

--- a/flock_agent/daemon/global_settings.py
+++ b/flock_agent/daemon/global_settings.py
@@ -112,7 +112,7 @@ class GlobalSettings(object):
 
             except:
                 # If there's an error loading settings, fallback to default settings
-                logger.info("error loading settings, falling back to default")
+                logger.warning("error loading settings, falling back to default")
                 self.settings = self.default_settings.copy()
 
         else:

--- a/flock_agent/daemon/osquery.py
+++ b/flock_agent/daemon/osquery.py
@@ -213,7 +213,7 @@ class Osquery(object):
                                         f"skipping \"{obj['name']}\" result, already submitted"
                                     )
                             else:
-                                logger.info(f"warning: unixTime not in line: {line}")
+                                logger.warning(f"warning: unixTime not in line: {line}")
 
                         except json.decoder.JSONDecodeError:
                             logger.warning(f"warning: line is not valid JSON: {line}")

--- a/flock_agent/daemon/osquery.py
+++ b/flock_agent/daemon/osquery.py
@@ -216,7 +216,7 @@ class Osquery(object):
                                 logger.info(f"warning: unixTime not in line: {line}")
 
                         except json.decoder.JSONDecodeError:
-                            logger.info(f"warning: line is not valid JSON: {line}")
+                            logger.warning(f"warning: line is not valid JSON: {line}")
 
                     # Submit them
                     api_client.submit(logs)
@@ -246,4 +246,4 @@ class Osquery(object):
                     results_file.truncate()
 
         except FileNotFoundError:
-            logger.info(f"warning: file not found: {self.results_filename}")
+            logger.warning(f"warning: file not found: {self.results_filename}")

--- a/flock_agent/gui/bootstrap.py
+++ b/flock_agent/gui/bootstrap.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
-import subprocess
 import shutil
-import appdirs
+import subprocess
 import time
-from PyQt5 import QtCore, QtWidgets, QtGui
+
+import appdirs
 
 from .gui_common import Alert
 from .daemon_client import DaemonNotRunningException, PermissionDeniedException
@@ -18,7 +19,8 @@ class Bootstrap(object):
 
     def __init__(self, common):
         self.c = common
-        self.c.log("Bootstrap", "__init__")
+        logger = logging.getLogger("Bootstrap.__init__")
+        logger.debug("")
 
     def go(self):
         """
@@ -26,18 +28,15 @@ class Bootstrap(object):
         """
         platform = Platform.current()
 
-        self.c.log("Bootstrap", "go", "Bootstrapping Flock Agent", always=True)
+        logger = logging.getLogger("Bootstrap.go")
+        logger.warning("Bootstrapping Flock Agent")
 
         if platform == Platform.UNKNOWN:
-            self.c.log(
-                "Bootstrap",
-                "go",
+            logger.warning(
                 "Unknown platform: Unable to make sure Flock Agent starts automatically",
             )
         else:
-            self.c.log(
-                "Bootstrap", "go", "Making sure Flock Agent starts automatically"
-            )
+            logger.info("Making sure Flock Agent starts automatically")
             if platform == Platform.MACOS:
                 autorun_dir = os.path.expanduser("~/Library/LaunchAgents")
                 autorun_filename = "media.firstlook.flock-agent.plist"
@@ -55,29 +54,33 @@ class Bootstrap(object):
             shutil.copy(src_filename, os.path.join(autorun_dir, autorun_filename))
 
         if platform == Platform.UNKNOWN:
-            self.c.log(
-                "Bootstrap",
-                "go",
-                "Unknown platform: Unable to make sure osquery is installed",
-            )
+            logger.warning("Unknown platform: Unable to make sure osquery is installed")
         else:
-            self.c.log("Bootstrap", "go", "Making sure osquery is installed")
+            logger.warning("Making sure osquery is installed")
             if platform == Platform.MACOS:
                 # macOS version doesn't check for osqueryi, which is just a symlink of
                 # osqueryd anyway -- the daemon's Osquery object the symlink if it isn't there
                 if not os.path.exists("/usr/local/bin/osqueryd"):
-                    message = '<b>Osquery is not installed.</b><br><br>You can either install it with Homebrew, or download it from <a href="https://osquery.io/downloads">https://osquery.io/downloads</a>. Install osquery and then run Flock again.'
+                    message = (
+                        "<b>Osquery is not installed.</b><br><br>You can either install it with Homebrew, or download it from "
+                        '<a href="https://osquery.io/downloads">https://osquery.io/downloads</a>. Install osquery and then run Flock again.'
+                    )
                     Alert(self.c, message, contains_links=True).launch()
                     return False
             elif platform == Platform.LINUX:
                 if not os.path.exists("/usr/bin/osqueryd") or not os.path.exists(
                     "/usr/bin/osqueryi"
                 ):
-                    message = '<b>Osquery is not installed.</b><br><br>To add the osquery repository to your system and install the osquery package, follow the instructions at <a href="https://osquery.io/downloads">https://osquery.io/downloads</a> under "Alternative Install Options".<br><br>For Debian, Ubuntu, or Mint, follow the "Debian Linux" instructions, and for Fedora, Red Hat, or CentOS, follow the "RPM Linux" instructions.<br><br>Install osquery and then run Flock again.'
+                    message = (
+                        "<b>Osquery is not installed.</b><br><br>To add the osquery repository to your system and install the osquery package, follow "
+                        'the instructions at <a href="https://osquery.io/downloads">https://osquery.io/downloads</a> under "Alternative Install '
+                        'Options".<br><br>For Debian, Ubuntu, or Mint, follow the "Debian Linux" instructions, and for Fedora, Red Hat, or CentOS, follow the '
+                        '"RPM Linux" instructions.<br><br>Install osquery and then run Flock again.'
+                    )
                     Alert(self.c, message, contains_links=True).launch()
                     return False
 
-        self.c.log("Bootstrap", "go", "Making sure the Flock Agent daemon is running")
+        logger.info("Making sure the Flock Agent daemon is running")
         connected = False
         permission_denied = False
         for _ in range(5):
@@ -86,10 +89,10 @@ class Bootstrap(object):
                 connected = True
                 break
             except DaemonNotRunningException:
-                self.c.log("Bootstrap", "go", "Failed to connect to daemon ...")
+                logger.info("Failed to connect to daemon ...")
                 time.sleep(1)
             except PermissionDeniedException:
-                self.c.log("Bootstrap", "go", "Permission denied ...")
+                logger.info("Permission denied ...")
                 permission_denied = True
                 time.sleep(1)
         if not connected:
@@ -99,23 +102,17 @@ class Bootstrap(object):
                 self.c.gui.daemon_not_running()
             return False
 
-        self.c.log("Bootstrap", "go", "Bootstrap complete")
+        logger.info("Bootstrap complete")
         return True
 
     def exec(self, command, capture_output=False):
         try:
             if type(command) == list:
-                self.c.log(
-                    "Bootstrap",
-                    "go",
-                    "Executing: {}".format(" ".join(command)),
-                    always=True,
-                )
+                logger = logging.getLogger("Bootstrap.exec")
+                logger.warning("Executing: {' '.join(command)}")
                 p = subprocess.run(command, capture_output=capture_output, check=True)
             else:
-                self.c.log(
-                    "Bootstrap", "go", "Executing: {}".format(command), always=True
-                )
+                logger.warning("Executing: {command}")
                 # If command is a string, shell must be true
                 p = subprocess.run(
                     command, shell=True, capture_output=capture_output, check=True

--- a/flock_agent/gui/bootstrap.py
+++ b/flock_agent/gui/bootstrap.py
@@ -29,7 +29,7 @@ class Bootstrap(object):
         platform = Platform.current()
 
         logger = logging.getLogger("Bootstrap.go")
-        logger.warning("Bootstrapping Flock Agent")
+        logger.info("Bootstrapping Flock Agent")
 
         if platform == Platform.UNKNOWN:
             logger.warning(
@@ -56,7 +56,7 @@ class Bootstrap(object):
         if platform == Platform.UNKNOWN:
             logger.warning("Unknown platform: Unable to make sure osquery is installed")
         else:
-            logger.warning("Making sure osquery is installed")
+            logger.info("Making sure osquery is installed")
             if platform == Platform.MACOS:
                 # macOS version doesn't check for osqueryi, which is just a symlink of
                 # osqueryd anyway -- the daemon's Osquery object the symlink if it isn't there
@@ -89,7 +89,7 @@ class Bootstrap(object):
                 connected = True
                 break
             except DaemonNotRunningException:
-                logger.info("Failed to connect to daemon ...")
+                logger.warning("Failed to connect to daemon ...")
                 time.sleep(1)
             except PermissionDeniedException:
                 logger.info("Permission denied ...")

--- a/flock_agent/gui/bootstrap.py
+++ b/flock_agent/gui/bootstrap.py
@@ -92,7 +92,7 @@ class Bootstrap(object):
                 logger.warning("Failed to connect to daemon ...")
                 time.sleep(1)
             except PermissionDeniedException:
-                logger.info("Permission denied ...")
+                logger.warning("Permission denied ...")
                 permission_denied = True
                 time.sleep(1)
         if not connected:

--- a/flock_agent/gui/daemon_client.py
+++ b/flock_agent/gui/daemon_client.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import logging
 import requests
 
 from .gui_common import Alert
@@ -104,13 +105,12 @@ class DaemonClient:
         return self._http_request("post", path, data)
 
     def _http_request(self, method, path, data=None):
+        logger = logging.getLogger("DaemonClient._http_request")
         url = "http+unix://{}{}".format(self.unix_socket_path.replace("/", "%2F"), path)
         if data:
-            self.c.log(
-                "DaemonClient", "_request", "{} {} {}".format(method, path, data)
-            )
+            logger.info(f"{method} {path} {data}")
         else:
-            self.c.log("DaemonClient", "_request", "{} {}".format(method, path))
+            logger.info(f"{method} {path}")
 
         try:
             if method == "get":
@@ -132,7 +132,7 @@ class DaemonClient:
         if r.status_code == 200:
             obj = json.loads(r.text)
             if obj["error"]:
-                self.c.log("DaemonClient", "_request", "Error: {}".format(obj["error"]))
+                logger.info(f"Error: {obj['error']}'")
             return obj
 
         raise UnknownErrorException

--- a/flock_agent/gui/daemon_client.py
+++ b/flock_agent/gui/daemon_client.py
@@ -132,7 +132,7 @@ class DaemonClient:
         if r.status_code == 200:
             obj = json.loads(r.text)
             if obj["error"]:
-                logger.info(f"Error: {obj['error']}'")
+                logger.warning(f"Error: {obj['error']}'")
             return obj
 
         raise UnknownErrorException

--- a/flock_agent/gui/gui_common.py
+++ b/flock_agent/gui/gui_common.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import logging
 import subprocess
+
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from .settings import Settings
@@ -164,10 +166,11 @@ class GuiCommon:
         """
         Handling when the daemon isn't running
         """
-        self.c.log("GuiCommon", "daemon_not_running")
+        logger = logging.getLogger("GuiCommon.daemon_not_running")
+        logger.debug("")
         message = "<b>Flock Agent daemon is not running.</b><br><br>Click Ok to try starting it in the background. You will have to type your login password."
         if Alert(self.c, message, has_cancel_button=True).launch():
-            self.c.log("GuiCommon", "daemon_not_running", "enabling background daemon")
+            logger.info("enabling background daemon")
             if Platform.current() == Platform.UNKNOWN:
                 # Unknown platform
                 message = "<b>Flock Agent doesn't recognize your operating system.</b><br><br>Sorry, I don't know how to start the daemon."
@@ -211,7 +214,8 @@ class GuiCommon:
         """
         Handling when permission to use the daemon is denied
         """
-        self.c.log("GuiCommon", "daemon_permission_denied")
+        logger = logging.getLogger("GuiCommon.daemon_permission_denied")
+        logger.debug("")
         message = "<b>Permission denied.</b><br><br>Sorry, you must have admin rights on your computer to configure Flock Agent."
         Alert(self.c, message).launch()
         # Quit the app

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import logging
+
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from .systray import SysTray
@@ -14,7 +16,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.app = app
         self.c = common
 
-        self.c.log("MainWindow", "__init__")
+        logger = logging.getLogger("MainWindow.__init__")
+        logger.debug("")
 
         self.setWindowTitle("Flock")
         self.setWindowIcon(self.c.gui.icon)
@@ -79,12 +82,14 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         Intercept close event, and instead minimize to systray
         """
-        self.c.log("MainWindow", "closeEvent", "Hiding window")
+        logger = logging.getLogger("MainWindow.closeEvent", "Hiding window")
+        logger.debug("")
         self.hide()
         e.ignore()
 
     def update_ui(self, active_tab=None):
-        self.c.log("MainWindow", "update_ui")
+        logger = logging.getLogger("MainWindow.update_ui")
+        logger.debug("")
 
         # Update the tabs
         self.opt_in_tab.update_ui()
@@ -163,14 +168,17 @@ class MainWindow(QtWidgets.QMainWindow):
             self.update_ui()
 
     def show_window(self):
-        self.c.log("MainWindow", "show_window")
+        logger = logging.getLogger("MainWindow.show_window")
+        logger.debug("")
         self.show()
         self.activateWindow()
         self.raise_()
 
     def quit(self):
-        self.c.log("MainWindow", "quit")
+        logger = logging.getLogger("MainWindow.quit")
+        logger.debug("")
         self.app.quit()
 
     def shutdown(self):
-        self.c.log("MainWindow", "shutdown")
+        logger = logging.getLogger("MainWindow.shutdown")
+        logger.debug("")

--- a/flock_agent/gui/onboarding.py
+++ b/flock_agent/gui/onboarding.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
+
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from .daemon_client import DaemonNotRunningException, PermissionDeniedException
@@ -157,7 +159,8 @@ class DataPage(QtWidgets.QWizardPage):
         return self.is_registered
 
     def server_button_clicked(self):
-        self.c.log("DataPage", "server_button_clicked")
+        logger = logging.getLogger("DataPage.server_button_clicked")
+        logger.debug("")
 
         self.server_button.setEnabled(False)
         self.server_button.setText("Registering...")
@@ -314,8 +317,9 @@ class Onboarding(QtWidgets.QWizard):
 
     def __init__(self, common):
         super(Onboarding, self).__init__()
+        logger = logging.getLogger("Onboarding.__init__")
         self.c = common
-        self.c.log("Onboarding", "__init__")
+        logger.debug("")
 
         self.setWindowTitle("Configuring Flock")
         self.setMinimumWidth(790)
@@ -384,5 +388,6 @@ class Onboarding(QtWidgets.QWizard):
         """
         Start the onboarding process
         """
-        self.c.log("Onboarding", "go", "Starting the onboarding wizard", always=True)
+        logger = logging.getLogger("Onboarding.go")
+        logger.warning("Starting the onboarding wizard")
         self.show()

--- a/flock_agent/gui/settings.py
+++ b/flock_agent/gui/settings.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-import os
 import json
+import logging
+import os
 
 
 class Settings(object):
     def __init__(self, common):
+        logger = logging.getLogger("Settings.__init__")
         self.c = common
         self.settings_filename = os.path.join(self.c.appdata_path, "settings.json")
-        self.c.log(
-            "Settings",
-            "__init__",
-            "settings_filename: {}".format(self.settings_filename),
-        )
+        logger.info(f"settings_filename: {self.settings_filename}")
 
         self.default_settings = {
             # First run
@@ -27,11 +25,13 @@ class Settings(object):
         return self.settings[key]
 
     def set(self, key, val):
-        self.c.log("Settings", "set", "{} = {}".format(key, val))
+        logger = logging.getLogger("Settings.set")
+        logger.debug(f"{key} = {value}")
         self.settings[key] = val
 
     def load(self):
-        self.c.log("Settings", "load")
+        logger = logging.getLogger("Settings.load")
+        logger.debug("")
         if os.path.isfile(self.settings_filename):
             # If the settings file exists, load it
             try:
@@ -45,16 +45,12 @@ class Settings(object):
 
             except:
                 # If there's an error loading settings, fallback to default settings
-                self.c.log(
-                    "Settings",
-                    "load",
-                    "error loading settings, falling back to default",
-                )
+                logger.info("error loading settings, falling back to default")
                 self.settings = self.default_settings
 
         else:
             # Save with default settings
-            self.c.log(
+            logger.info(
                 "Settings", "load", "settings file doesn't exist, starting with default"
             )
             self.settings = self.default_settings
@@ -62,7 +58,8 @@ class Settings(object):
         self.save()
 
     def save(self):
-        self.c.log("Settings", "save")
+        logger = logging.getLogger("Settings.save")
+        logger.debug("")
         os.makedirs(self.c.appdata_path, exist_ok=True)
         with open(self.settings_filename, "w") as settings_file:
             json.dump(self.settings, settings_file, indent=4)

--- a/flock_agent/gui/settings.py
+++ b/flock_agent/gui/settings.py
@@ -26,7 +26,7 @@ class Settings(object):
 
     def set(self, key, val):
         logger = logging.getLogger("Settings.set")
-        logger.debug(f"{key} = {value}")
+        logger.debug(f"{key} = {val}")
         self.settings[key] = val
 
     def load(self):

--- a/flock_agent/gui/tabs/health_tab.py
+++ b/flock_agent/gui/tabs/health_tab.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import logging
+
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from ...health import health_items
@@ -11,10 +13,11 @@ class HealthTab(QtWidgets.QWidget):
     """
 
     def __init__(self, common):
+        logger = logging.getLogger("HealthTab.__init__")
         super(HealthTab, self).__init__()
         self.c = common
 
-        self.c.log("HealthTab", "__init__")
+        logger.debug("")
 
         # Health item widgets
         self.health_item_widgets = []
@@ -49,7 +52,8 @@ class HealthTab(QtWidgets.QWidget):
         self.refresh()
 
     def refresh(self):
-        self.c.log("HealthTab", "refresh")
+        logger = logging.getLogger("HealthTab.refresh")
+        logger.debug("")
         for widget in self.health_item_widgets:
             widget.refresh()
 
@@ -57,10 +61,11 @@ class HealthTab(QtWidgets.QWidget):
 class HealthItemWidget(QtWidgets.QWidget):
     def __init__(self, common, health_item):
         super(HealthItemWidget, self).__init__()
+        logger = logging.getLogger("HealthItemWidget.__init__")
         self.c = common
         self.health_item = health_item
 
-        self.c.log("HealthItemWidget", "__init__", self.health_item["name"])
+        logger.info(f"{self.health_item['name']}")
 
         # Widgets
         self.good_image = QtWidgets.QLabel()
@@ -100,7 +105,7 @@ class HealthItemWidget(QtWidgets.QWidget):
     def refresh(self):
         self.good_image.hide()
         self.bad_image.hide()
-        self.label.setText("Loading: {} ...".format(self.health_item["name"]))
+        self.label.setText(f"Loading: {self.health_item['name']} ...")
 
         # Run the osquery command in a separate thread
         self.t = HealthOsqueryThread(self.c, self.health_item["name"])
@@ -126,13 +131,10 @@ class HealthItemWidget(QtWidgets.QWidget):
         self.help_button.show()
 
     def help_button_clicked(self):
-        self.c.log(
-            "HealthItem",
-            "help_button_clicked",
-            "name={}, help clicked, loading {}".format(
-                self.health_item["name"], self.health_item["help_url"]
-            ),
-        )
+        logger = logging.getLogger("HealthItemWidget.help_button_clicked")
+        logger.debug(
+            f"name={self.health_item['name']}, help clicked, loading {self.health_item['help_url']}"
+        ),
         QtGui.QDesktopServices.openUrl(QtCore.QUrl(self.health_item["help_url"]))
 
 

--- a/flock_agent/gui/tabs/homebrew_tab.py
+++ b/flock_agent/gui/tabs/homebrew_tab.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-import subprocess
+import logging
 import os
-from PyQt5 import QtCore, QtWidgets, QtGui
+import subprocess
+
+from PyQt5 import QtCore, QtWidgets
 
 
 class HomebrewTab(QtWidgets.QWidget):
@@ -12,7 +14,8 @@ class HomebrewTab(QtWidgets.QWidget):
         self.c = common
         self.systray = systray
 
-        self.c.log("HomebrewTab", "__init__")
+        logger = logging.getLogger("HomebrewTab.__init__")
+        logger.debug("")
 
         self.should_show = False
         self.outdated_casks = []
@@ -69,12 +72,9 @@ class HomebrewTab(QtWidgets.QWidget):
         self.homebrew_thread.start()
 
     def updates_available(self, outdated_formulae, outdated_casks):
-        self.c.log(
-            "HomebrewTab",
-            "updates_available",
-            "outdated_formulae: {}, outdated_casks: {}".format(
-                outdated_formulae, outdated_casks
-            ),
+        logger = logging.getLogger("HomebrewTab.updates_available")
+        logger.info(
+            f"outdated_formulae: {outdated_formulae}, outdated_casks: {outdated_casks}"
         )
 
         self.outdated_casks = outdated_casks
@@ -104,11 +104,13 @@ class HomebrewTab(QtWidgets.QWidget):
         self.update_homebrew_tab.emit()
 
     def installing_updates(self, package_list):
-        self.c.log("HomebrewTab", "homebrew_installing_updates", package_list)
+        logger = logging.getLogger("HomebrewTab.homebrew_installing_updates")
+        logger.info("{package_list}")
         self.systray.showMessage("Installing Homebrew Updates", "\n".join(package_list))
 
     def clicked_install_updates_button(self):
-        self.c.log("HomebrewTab", "clicked_install_updates_button")
+        logger = logging.getLogger("HomebrewTab.clicked_install_updates_button")
+        logger.debug("")
 
         self.should_show = False
         self.update_homebrew_tab.emit()
@@ -144,15 +146,12 @@ class HomebrewUpdateCheckThread(QtCore.QThread):
         self.homebrew_path = "/usr/local/bin/brew"
 
     def run(self):
-        self.c.log("HomebrewUpdateCheckThread", "run")
+        logger = logging.getLogger("HomebrewUpdateCheckThread.run")
+        logger.debug("")
 
         # If homebrew is not installed, skip
         if not os.path.exists(self.homebrew_path):
-            self.c.log(
-                "HomebrewUpdateCheckThread",
-                "run",
-                "Homebrew is not installed, returning early",
-            )
+            logger.info("Homebrew is not installed, returning early")
             return
 
         homebrew_update_prompt = self.c.gui.settings.get("homebrew_update_prompt")
@@ -200,19 +199,11 @@ class HomebrewUpdateCheckThread(QtCore.QThread):
 
     def exec(self, command):
         try:
-            self.c.log(
-                "HomebrewUpdateCheckThread",
-                "exec",
-                "Executing: {}".format(" ".join(command)),
-                always=True,
-            )
+            logger = logging.getLogger("HomebrewUpdateCheckThread.exec")
+
+            logger.warning(f"Executing: {' '.join(command)}")
             p = subprocess.run(command, capture_output=True, check=True)
             return p
         except subprocess.CalledProcessError:
-            self.c.log(
-                "HomebrewUpdateCheckThread",
-                "exec",
-                "Error running command",
-                always=True,
-            )
+            logger.warning("Error running command")
             return False

--- a/flock_agent/gui/tabs/settings_tab.py
+++ b/flock_agent/gui/tabs/settings_tab.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import logging
+
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from ..gui_common import Alert, HidableSpacer
@@ -21,7 +23,8 @@ class SettingsTab(QtWidgets.QWidget):
         super(SettingsTab, self).__init__()
         self.c = common
 
-        self.c.log("SettingsTab", "__init__")
+        logger = logging.getLogger("SettingsTab.__init__")
+        logger.debug("")
 
         # Use server checkbox
         self.use_server_checkbox = QtWidgets.QCheckBox(
@@ -134,7 +137,8 @@ class SettingsTab(QtWidgets.QWidget):
         self.update_ui()
 
     def update_ui(self):
-        self.c.log("SettingsTab", "update_ui")
+        logger = logging.getLogger("SettingsTab.update_ui")
+        logger.debug("")
 
         try:
             # Determine server status
@@ -213,7 +217,8 @@ class SettingsTab(QtWidgets.QWidget):
             self.c.gui.daemon_permission_denied()
 
     def server_button_clicked(self):
-        self.c.log("SettingsTab", "server_button_clicked")
+        logger = logging.getLogger("SettingsTab.server_button_clicked")
+        logger.debug("")
 
         if self.status == self.STATUS_NOT_REGISTERED:
             self.server_button.setEnabled(False)
@@ -234,7 +239,8 @@ class SettingsTab(QtWidgets.QWidget):
         self.update_ui()
 
     def use_server_toggled(self):
-        self.c.log("SettingsTab", "use_server_toggled")
+        logger = logging.getLogger("SettingsTab.use_server_toggled")
+        logger.debug("")
         is_checked = (
             self.use_server_checkbox.checkState() == QtCore.Qt.CheckState.Checked
         )
@@ -250,7 +256,8 @@ class SettingsTab(QtWidgets.QWidget):
         self.update_ui()
 
     def automatically_enable_twigs_toggled(self):
-        self.c.log("SettingsTab", "automatically_enable_twigs_toggled")
+        logger = logging.getLogger("SettingsTab.automatically_enable_twigs_toggled")
+        logger.debug("")
         is_checked = (
             self.automatically_enable_twigs_checkbox.checkState()
             == QtCore.Qt.CheckState.Checked
@@ -263,7 +270,8 @@ class SettingsTab(QtWidgets.QWidget):
             self.c.gui.daemon_permission_denied()
 
     def homebrew_update_prompt_toggled(self):
-        self.c.log("SettingsTab", "homebrew_update_prompt_toggled")
+        logger = logging.getLogger("SettingsTab.homebrew_update_prompt_toggled")
+        logger.debug("")
         is_checked = (
             self.homebrew_update_prompt_checkbox.checkState()
             == QtCore.Qt.CheckState.Checked
@@ -272,7 +280,8 @@ class SettingsTab(QtWidgets.QWidget):
         self.c.gui.settings.save()
 
     def homebrew_autoupdate_toggled(self):
-        self.c.log("SettingsTab", "homebrew_autoupdate_toggled")
+        logger = logging.getLogger("SettingsTab.homebrew_autoupdate_toggled")
+        logger.debug("")
         is_checked = (
             self.homebrew_autoupdate_checkbox.checkState()
             == QtCore.Qt.CheckState.Checked
@@ -281,5 +290,6 @@ class SettingsTab(QtWidgets.QWidget):
         self.c.gui.settings.save()
 
     def quit_clicked(self):
-        self.c.log("SettingsTab", "quit_clicked")
+        logger = logging.getLogger("SettingsTab.quit_clicked")
+        logger.debug("")
         self.quit.emit()

--- a/flock_agent/gui/tabs/twigs_tab.py
+++ b/flock_agent/gui/tabs/twigs_tab.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import logging
+
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from ..twigs import TwigView
@@ -22,8 +24,8 @@ class TwigsTab(QtWidgets.QWidget):
             self.mode = "opt-in"
         else:
             self.mode = "data"
-
-        self.c.log("TwigsTab ({})".format(self.mode), "__init__")
+        logger = logging.getLogger("TwigsTab.__init__")
+        logger.debug(f"mode:  ({self.mode})")
 
         # Keep track of the twig views
         self.twig_views = []
@@ -81,7 +83,8 @@ class TwigsTab(QtWidgets.QWidget):
         self.setLayout(layout)
 
     def update_ui(self):
-        self.c.log("TwigsTab ({})".format(self.mode), "update_ui")
+        logger = logging.getLogger("TwigsTab.update_ui")
+        logger.debug(f"mode: {self.mode}")
 
         # Remove all twig views from the layout
         for twig_view in self.twig_views:
@@ -116,18 +119,16 @@ class TwigsTab(QtWidgets.QWidget):
 
     def clicked_enable_all_button(self):
         if self.mode == "opt-in":
-            self.c.log("TwigsTab ({})".format(self.mode), "clicked_enable_all_button")
+            logger = logging.getLogger("TwigsTab.clicked_enable_all_button")
+            logger.debug(f"mode: {self.mode}")
 
             try:
                 if (
                     self.automatically_enable_twigs_checkbox.checkState()
                     == QtCore.Qt.CheckState.Checked
                 ):
-                    self.c.log(
-                        "TwigsTab ({})".format(self.mode),
-                        "clicked_enable_all_button",
-                        "automatically_enable_twigs=True",
-                    )
+
+                    logger.debug("automatically_enable_twigs=True")
                     self.c.daemon.set("automatically_enable_twigs", True)
 
                 self.c.daemon.enable_undecided_twigs()
@@ -141,7 +142,8 @@ class TwigsTab(QtWidgets.QWidget):
             self.refresh.emit(self.mode)
 
     def clicked_apply_button(self):
-        self.c.log("TwigsTab ({})".format(self.mode), "clicked_apply_button")
+        logger = logging.getLogger("TwigsTab.clicked_apply_button")
+        logger.debug("mode: {self.mode}")
 
         # Build twig_status that maps the existing opt-in status of each twig
         try:

--- a/flock_agent/gui/twigs.py
+++ b/flock_agent/gui/twigs.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from PyQt5 import QtCore, QtWidgets, QtGui
+import logging
+
+from PyQt5 import QtCore, QtWidgets
 
 from ..twigs import twigs
 
@@ -70,10 +72,11 @@ class TwigDialog(QtWidgets.QDialog):
 
     def __init__(self, common, twig_id):
         super(TwigDialog, self).__init__()
+        logger = logging.getLogger("TwigDialog.__init__")
         self.c = common
         self.twig_id = twig_id
 
-        self.c.log("TwigDialog", "__init__", twig_id)
+        logger.info(twig_id)
 
         self.setWindowTitle("Details of: {}".format(twigs[self.twig_id]["name"]))
         self.setWindowIcon(self.c.gui.icon)
@@ -158,7 +161,8 @@ class TwigDialog(QtWidgets.QDialog):
         return text
 
     def query_finished(self, data):
-        self.c.log("TwigDialog", "query_finished")
+        logger = logging.getLogger("TwigDialog.query_finished")
+        logger.debug("")
 
         # Count rows and columns
         row_count = len(data)
@@ -208,12 +212,14 @@ class TwigOsqueryThread(QtCore.QThread):
 
     def __init__(self, common, twig_id):
         super(TwigOsqueryThread, self).__init__()
+        logger = logging.getLogger("TwigOsqueryThread.__init__")
         self.c = common
         self.twig_id = twig_id
-        self.c.log("TwigOsqueryThread", "__init__", twig_id)
+        logger.debug(f"{twig_id}")
 
     def run(self):
-        self.c.log("TwigOsqueryThread", "run")
+        logger = logging.getLogger("TwigOsqueryThread.run")
+        logger.debug("")
 
         try:
             data = self.c.daemon.exec_twig(self.twig_id)


### PR DESCRIPTION
Switches away from common's log() function and uses the python logging module instead.

Also splits what was previously just --verbose into --debug and --verbose. Debug has more info
that's less likely to be used. By default, only WARNING and above are printed to the console, and
INFO and above are printed to the log file. Using verbose prints INFO to the console as well, and
using debug prints DEBUG messages to both the console and a file. Verbose and debug both add extra
context to the console log messages as well

aiohttp's logs are also now automatically handled by the loggers, rather than needing to be hooked
up manually.

Fixes #61