### PR TITLE
Fix permission denied error on boot

### DIFF
--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -476,6 +476,6 @@ class Daemon:
                 )
                 await asyncio.sleep(30)
 
-    def cleanup(self, sig=None, frame=None):
+    def cleanup(self):
         if os.path.exists(self.unix_socket_path):
             os.remove(self.unix_socket_path)


### PR DESCRIPTION
This makes sure that the daemon's update check loop uses `await` to make the HTTP request to check for updates, and also await sleeps for 30 seconds on error, which allows the rest of the daemon to continue running, instead of stalling it until there's internet access.

Resolves #101.