### PR TITLE
Properly display error messages from the server

### DIFF
--- a/flock_agent/daemon/api_client.py
+++ b/flock_agent/daemon/api_client.py
@@ -129,27 +129,27 @@ class FlockApiClient(object):
         if res.status_code == 401:
             raise PermissionDenied()
 
-        if res.status_code == 400:
-            try:
-                obj = res.json()
-            except ValueError:
-                raise ResponseIsNotJson()
+        if res.status_code == 200 or res.status_code == 400:
+            if res.content:
+                try:
+                    obj = res.json()
+                except ValueError:
+                    raise ResponseIsNotJson()
 
-            if obj["error"]:
-                if "error_msg" in obj:
-                    raise RespondedWithError(obj["error_msg"])
-                else:
+                if "error" not in obj:
                     raise InvalidResponse()
+
+                if obj["error"]:
+                    if "error_msg" in obj:
+                        raise RespondedWithError(obj["error_msg"])
+                    else:
+                        raise InvalidResponse()
+
+                if res.status_code == 200:
+                    return obj
 
         if res.status_code != 200:
             raise BadStatusCode(res)
-
-        if res.content:
-            try:
-                obj = res.json()
-            except ValueError:
-                raise ResponseIsNotJson()
-            return obj
 
     def _build_url(self, path):
         """

--- a/flock_agent/daemon/daemon.py
+++ b/flock_agent/daemon/daemon.py
@@ -157,13 +157,14 @@ class Daemon:
                 return response_object(error="invalid key")
 
         async def set_setting(request):
+            logger = logging.getLogger("Daemon.http_server.set_settings")
+
             key = request.match_info.get("key", None)
             val = await request.json()
 
             # Only change the setting if it's actually changing
             old_val = self.global_settings.get(key)
             if old_val == val:
-                logger = logging.getLogger("Daemon.http_server.set_settings")
                 logger.debug(f"skipping {key}={val}, because it's already set",)
             else:
                 logger.debug(f"setting {key}={val}")

--- a/flock_agent/gui/settings.py
+++ b/flock_agent/gui/settings.py
@@ -50,9 +50,7 @@ class Settings(object):
 
         else:
             # Save with default settings
-            logger.info(
-                "Settings", "load", "settings file doesn't exist, starting with default"
-            )
+            logger.info("settings file doesn't exist, starting with default")
             self.settings = self.default_settings
 
         self.save()

--- a/tests/daemon/test_api_client.py
+++ b/tests/daemon/test_api_client.py
@@ -98,12 +98,12 @@ class TestApiClient:
         }
         common = self._build_common()
         responses.add(
-            responses.GET, f"{self.test_url}/test", json=response_data, status=200,
+            responses.GET, f"{self.test_url}/test", json=response_data, status=400,
         )
         with pytest.raises(api_client.RespondedWithError) as excinfo:
             FlockApiClient(common)._make_request("/test", "get", False)
         responses.add(
-            responses.POST, f"{self.test_url}/test", json=response_data, status=200,
+            responses.POST, f"{self.test_url}/test", json=response_data, status=400,
         )
         with pytest.raises(api_client.RespondedWithError) as excinfo:
             FlockApiClient(common)._make_request("/test", "post", False)
@@ -119,12 +119,12 @@ class TestApiClient:
         }
         common = self._build_common()
         responses.add(
-            responses.GET, f"{self.test_url}/test", json=response_data, status=200,
+            responses.GET, f"{self.test_url}/test", json=response_data, status=400,
         )
         with pytest.raises(api_client.InvalidResponse) as excinfo:
             FlockApiClient(common)._make_request("/test", "get", False)
         responses.add(
-            responses.POST, f"{self.test_url}/test", json=response_data, status=200,
+            responses.POST, f"{self.test_url}/test", json=response_data, status=400,
         )
         with pytest.raises(api_client.InvalidResponse) as excinfo:
             FlockApiClient(common)._make_request("/test", "post", False)


### PR DESCRIPTION
Resolves #99.

When the server responds with error code 400 and an error message, this now allows that error message to get handled properly and displayed in an Alert dialog.

Also, fixes a couple of small logger bugs.