### PR TITLE
Support Ubuntu 18.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,17 @@ jobs:
 
   test:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: debian:buster
     steps:
       - checkout
       - run:
           name: Install dependencies
-          command: pipenv install --dev
+          command: |
+            apt-get update
+            apt-get install -y build-essential fakeroot python-all python3-all python3-stdeb dh-python python3-pyqt5 python3-requests python3-appdirs python3-aiohttp python3-packaging python3-pytest python3-responses
       - run:
           name: Run tests
-          command: pipenv run python -m pytest tests
+          command: python3 -m pytest tests
 
   build-ubuntu-bionic:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,30 @@ jobs:
           name: Run tests
           command: pipenv run python -m pytest tests
 
+  build-ubuntu-bionic:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get update
+            apt-get install -y git ssh ruby-dev rubygems build-essential fakeroot python-all python3-all python3-stdeb dh-python python3-pyqt5 python3-requests python3-appdirs python3-aiohttp python3-packaging
+            gem install --no-ri --no-rdoc rake
+            gem install --no-ri --no-rdoc package_cloud
+      - checkout
+      - run:
+          name: Create the .deb package
+          command: |
+            ./install/linux/build_deb.py
+            dpkg -i deb_dist/flock-agent_*-1_all.deb
+      - run:
+          name: Deploy to packagecloud.io
+          command: |
+            VERSION=$(cat flock_agent/__init__.py |grep "flock_agent_version = " |cut -d '"' -f2)
+            package_cloud push firstlookmedia/code/ubuntu/bionic deb_dist/flock-agent_${VERSION}-1_all.deb
+            package_cloud push firstlookmedia/code/ubuntu/bionic deb_dist/flock-agent_${VERSION}-1.dsc
+
   build-ubuntu-disco:
     docker:
       - image: ubuntu:19.04
@@ -161,6 +185,12 @@ workflows:
       - test
   build-tags:
     jobs:
+      - build-ubuntu-bionic:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - build-ubuntu-disco:
           filters:
             tags:
@@ -197,13 +227,3 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-
-      # Commenting out ubuntu 18.04 for now because Flock Agent requires python 3.7+, and
-      # 18.04 comes with 3.6. This problem is solvable, but I'll wait to see if there's any
-      # demand before trying to solve it
-      # - build-ubuntu-bionic:
-      #     filters:
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         ignore: /.*/

--- a/flock_agent/daemon/__init__.py
+++ b/flock_agent/daemon/__init__.py
@@ -5,7 +5,13 @@ from .daemon import Daemon
 
 def main(common):
     d = Daemon(common)
-    asyncio.run(d.start())
+
+    # This requires python 3.7+
+    # asyncio.run(d.start())
+
+    # This works in python 3.6
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(asyncio.wait([d.start()]))
 
 
 def stop(common):

--- a/flock_agent/daemon/osquery.py
+++ b/flock_agent/daemon/osquery.py
@@ -156,7 +156,7 @@ class Osquery(object):
         logger.info(query)
         try:
             p = subprocess.run(
-                [self.osqueryi_bin, "--json", query], capture_output=True, check=True
+                [self.osqueryi_bin, "--json", query], stdout=subprocess.PIPE, check=True
             )
             logger.info(f"{repr(p.stdout)}")
             return json.loads(p.stdout)

--- a/flock_agent/daemon/osquery.py
+++ b/flock_agent/daemon/osquery.py
@@ -93,7 +93,7 @@ class Osquery(object):
                     subprocess.run(["/bin/launchctl", "unload", self.plist_filename])
             elif Platform.current() == Platform.LINUX:
                 subprocess.run(
-                    ["/usr/bin/pkexec", "/usr/bin/systemctl", "stop", "osqueryd"]
+                    ["/usr/bin/pkexec", "/bin/systemctl", "stop", "osqueryd"]
                 )
 
             # Write the config file
@@ -125,10 +125,10 @@ class Osquery(object):
                 subprocess.run(["/bin/launchctl", "load", self.plist_filename])
             elif Platform.current() == Platform.LINUX:
                 subprocess.run(
-                    ["/usr/bin/pkexec", "/usr/bin/systemctl", "start", "osqueryd"]
+                    ["/usr/bin/pkexec", "/bin/systemctl", "start", "osqueryd"]
                 )
                 subprocess.run(
-                    ["/usr/bin/pkexec", "/usr/bin/systemctl", "enable", "osqueryd"]
+                    ["/usr/bin/pkexec", "/bin/systemctl", "enable", "osqueryd"]
                 )
 
         else:
@@ -142,10 +142,10 @@ class Osquery(object):
                     os.remove(self.plist_filename)
             elif Platform.current() == Platform.LINUX:
                 subprocess.run(
-                    ["/usr/bin/pkexec", "/usr/bin/systemctl", "stop", "osqueryd"]
+                    ["/usr/bin/pkexec", "/bin/systemctl", "stop", "osqueryd"]
                 )
                 subprocess.run(
-                    ["/usr/bin/pkexec", "/usr/bin/systemctl", "disable", "osqueryd"]
+                    ["/usr/bin/pkexec", "/bin/systemctl", "disable", "osqueryd"]
                 )
 
     def exec(self, query):

--- a/flock_agent/gui/__init__.py
+++ b/flock_agent/gui/__init__.py
@@ -9,6 +9,15 @@ from .onboarding import Onboarding
 from .main_window import MainWindow
 
 
+# Different versions of PyQt5 have differences in QtCore.Qt.CheckState
+# Monkey patch them here
+try:
+    checked = QtCore.Qt.CheckState.Checked
+except:
+    QtCore.Qt.CheckState.Checked = QtCore.Qt.Checked
+    QtCore.Qt.CheckState.Unchecked = QtCore.Qt.Unchecked
+
+
 def main(common):
     # Create the Qt app
     app = QtWidgets.QApplication(sys.argv)

--- a/flock_agent/gui/bootstrap.py
+++ b/flock_agent/gui/bootstrap.py
@@ -110,13 +110,30 @@ class Bootstrap(object):
             if type(command) == list:
                 logger = logging.getLogger("Bootstrap.exec")
                 logger.warning("Executing: {' '.join(command)}")
-                p = subprocess.run(command, capture_output=capture_output, check=True)
+                if capture_output:
+                    p = subprocess.run(
+                        command,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        check=True,
+                    )
+                else:
+                    p = subprocess.run(command, check=True)
             else:
                 logger.warning("Executing: {command}")
                 # If command is a string, shell must be true
-                p = subprocess.run(
-                    command, shell=True, capture_output=capture_output, check=True
-                )
+                if capture_output:
+                    p = subprocess.run(
+                        command,
+                        shell=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        check=True,
+                    )
+                else:
+                    p = subprocess.run(
+                        command, shell=True, check=True
+                    )
             return p
         except subprocess.CalledProcessError:
             message = "Error running <br><b>{}</b>.".format(" ".join(command))

--- a/flock_agent/gui/main_window.py
+++ b/flock_agent/gui/main_window.py
@@ -82,8 +82,8 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         Intercept close event, and instead minimize to systray
         """
-        logger = logging.getLogger("MainWindow.closeEvent", "Hiding window")
-        logger.debug("")
+        logger = logging.getLogger("MainWindow.closeEvent")
+        logger.debug("Hiding window")
         self.hide()
         e.ignore()
 

--- a/share/autostart/linux/enable_daemon
+++ b/share/autostart/linux/enable_daemon
@@ -1,4 +1,4 @@
 #!/bin/sh
-/usr/bin/systemctl enable flock-agent.service
-/usr/bin/systemctl start flock-agent.service
+/bin/systemctl enable flock-agent.service
+/bin/systemctl start flock-agent.service
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,4 +3,4 @@ Package3: flock-agent
 Depends3: python3, python3-pyqt5, python3-requests, python3-appdirs, python3-aiohttp, python3-packaging
 Build-Depends: python3, python3-all
 Suite: bionic
-X-Python3-Version: >= 3.7
+X-Python3-Version: >= 3.6


### PR DESCRIPTION
This makes a few small changes to work in Ubuntu 18.04. Specifically, it stops using new features that are available in python 3.7+ and does everything in python 3.6, and the path to systemctl is `/bin/systemctl` instead of `/usr/bin/systemctl`.